### PR TITLE
Rename crypto_sign_publickey to crypto_sign_seed_keypair

### DIFF
--- a/src/libsodium/crypto_sign/ed25519/ref/crypto_sign.h
+++ b/src/libsodium/crypto_sign/ed25519/ref/crypto_sign.h
@@ -6,7 +6,7 @@
 #define crypto_sign crypto_sign_ed25519
 #define crypto_sign_open crypto_sign_ed25519_open
 #define crypto_sign_keypair crypto_sign_ed25519_keypair
-#define crypto_sign_publickey crypto_sign_ed25519_publickey
+#define crypto_sign_seed_keypair crypto_sign_ed25519_seed_keypair
 #define crypto_sign_BYTES crypto_sign_ed25519_BYTES
 #define crypto_sign_PUBLICKEYBYTES crypto_sign_ed25519_PUBLICKEYBYTES
 #define crypto_sign_SECRETKEYBYTES crypto_sign_ed25519_SECRETKEYBYTES

--- a/src/libsodium/crypto_sign/ed25519/ref/ed25519_ed25519.c
+++ b/src/libsodium/crypto_sign/ed25519/ref/ed25519_ed25519.c
@@ -28,10 +28,10 @@ int crypto_sign_keypair(
   unsigned char seed[32];
 
   randombytes(seed, 32);
-  crypto_sign_publickey(pk, sk, seed);
+  crypto_sign_seed_keypair(pk, sk, seed);
 }
 
-int crypto_sign_publickey(
+int crypto_sign_seed_keypair(
     unsigned char *pk,
     unsigned char *sk,
     unsigned char *seed

--- a/src/libsodium/include/sodium/crypto_sign_ed25519.h
+++ b/src/libsodium/include/sodium/crypto_sign_ed25519.h
@@ -12,7 +12,7 @@ extern "C" {
 extern int crypto_sign_ed25519_ref(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
 extern int crypto_sign_ed25519_ref_open(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
 extern int crypto_sign_ed25519_ref_keypair(unsigned char *,unsigned char *);
-extern int crypto_sign_ed25519_ref_publickey(unsigned char *,unsigned char *,unsigned char *);
+extern int crypto_sign_ed25519_ref_seed_keypair(unsigned char *,unsigned char *,unsigned char *);
 #ifdef __cplusplus
 }
 #endif
@@ -20,7 +20,7 @@ extern int crypto_sign_ed25519_ref_publickey(unsigned char *,unsigned char *,uns
 #define crypto_sign_ed25519 crypto_sign_ed25519_ref
 #define crypto_sign_ed25519_open crypto_sign_ed25519_ref_open
 #define crypto_sign_ed25519_keypair crypto_sign_ed25519_ref_keypair
-#define crypto_sign_ed25519_publickey crypto_sign_ed25519_ref_publickey
+#define crypto_sign_ed25519_seed_keypair crypto_sign_ed25519_ref_seed_keypair
 #define crypto_sign_ed25519_BYTES crypto_sign_ed25519_ref_BYTES
 #define crypto_sign_ed25519_PUBLICKEYBYTES crypto_sign_ed25519_ref_PUBLICKEYBYTES
 #define crypto_sign_ed25519_SECRETKEYBYTES crypto_sign_ed25519_ref_SECRETKEYBYTES


### PR DESCRIPTION
The crypto_sign_seed_keypair function is analagous to
crypto_sign_keypair, except it generates a keypair for a seed instead of
a random keypair.

I think this name makes more sense than crypto_sign_publickey.
