### PR TITLE
Fix bitshift overflow error on 32-bit archs

### DIFF
--- a/src/libsodium/crypto_scalarmult/curve25519/donna_c64/smult.c
+++ b/src/libsodium/crypto_scalarmult/curve25519/donna_c64/smult.c
@@ -42,7 +42,7 @@ static void fsum(felem *output, const felem *in) {
  * (note the order of the arguments!)
  */
 static void fdifference_backwards(felem *ioutput, const felem *iin) {
-  static const int64_t twotothe51 = (1l << 51);
+  static const int64_t twotothe51 = (1ll << 51);
   const int64_t *in = (const int64_t *) iin;
   int64_t *out = (int64_t *) ioutput;
 


### PR DESCRIPTION
When compiling libsodium for a 32-bit architecture (in my case, armv7s, compiled with clang), throws the following warning:

```
src/libsodium/crypto_scalarmult/curve25519/donna_c64/smult.c:45:41: warning: shift count >= width of type [-Wshift-count-overflow]
```

This commit fixes this by changes `1l` (which is only guaranteed to be 32-bit) into `1ll` which is a 64-bit value.
