### PR TITLE
Compatibility with Microsoft compilers

### DIFF
--- a/dist-build/msvc/libsodium/libsodium.sln
+++ b/dist-build/msvc/libsodium/libsodium.sln
@@ -1,0 +1,38 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libsodium", "libsodium\libsodium.vcxproj", "{A185B162-6CB6-4502-B03F-B56F7699A8D9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		DebugDLL|Win32 = DebugDLL|Win32
+		DebugDLL|x64 = DebugDLL|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+		ReleaseDLL|Win32 = ReleaseDLL|Win32
+		ReleaseDLL|x64 = ReleaseDLL|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.Debug|Win32.ActiveCfg = Debug|Win32
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.Debug|Win32.Build.0 = Debug|Win32
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.Debug|x64.ActiveCfg = Debug|x64
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.Debug|x64.Build.0 = Debug|x64
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.DebugDLL|Win32.ActiveCfg = DebugDLL|Win32
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.DebugDLL|Win32.Build.0 = DebugDLL|Win32
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.DebugDLL|x64.ActiveCfg = DebugDLL|x64
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.DebugDLL|x64.Build.0 = DebugDLL|x64
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.Release|Win32.ActiveCfg = Release|Win32
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.Release|Win32.Build.0 = Release|Win32
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.Release|x64.ActiveCfg = Release|x64
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.Release|x64.Build.0 = Release|x64
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.ReleaseDLL|Win32.ActiveCfg = ReleaseDLL|Win32
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.ReleaseDLL|Win32.Build.0 = ReleaseDLL|Win32
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.ReleaseDLL|x64.ActiveCfg = ReleaseDLL|x64
+		{A185B162-6CB6-4502-B03F-B56F7699A8D9}.ReleaseDLL|x64.Build.0 = ReleaseDLL|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/dist-build/msvc/libsodium/libsodium/libsodium.vcxproj
+++ b/dist-build/msvc/libsodium/libsodium/libsodium.vcxproj
@@ -1,0 +1,558 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="DebugDLL|Win32">
+      <Configuration>DebugDLL</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="DebugDLL|x64">
+      <Configuration>DebugDLL</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseDLL|Win32">
+      <Configuration>ReleaseDLL</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseDLL|x64">
+      <Configuration>ReleaseDLL</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A185B162-6CB6-4502-B03F-B56F7699A8D9}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>libsodium</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)Build\$(Configuration)\$(Platform)\Intermediate\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;SODIUM_STATIC;SODIUM_EXPORT=;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\..\..\src\libsodium\include\sodium;$(SolutionDir)..\..\..\src\libsodium\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;SODIUM_EXPORT=__declspec(dllexport);DLL_EXPORT;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\..\..\src\libsodium\include\sodium;$(SolutionDir)..\..\..\src\libsodium\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;SODIUM_STATIC;SODIUM_EXPORT=;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\..\..\src\libsodium\include\sodium;$(SolutionDir)..\..\..\src\libsodium\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;SODIUM_EXPORT=__declspec(dllexport);DLL_EXPORT;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\..\..\src\libsodium\include\sodium;$(SolutionDir)..\..\..\src\libsodium\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;SODIUM_STATIC;SODIUM_EXPORT=;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\..\..\src\libsodium\include\sodium;$(SolutionDir)..\..\..\src\libsodium\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;SODIUM_EXPORT=__declspec(dllexport);DLL_EXPORT;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\..\..\src\libsodium\include\sodium;$(SolutionDir)..\..\..\src\libsodium\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;SODIUM_STATIC;SODIUM_EXPORT=;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\..\..\src\libsodium\include\sodium;$(SolutionDir)..\..\..\src\libsodium\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;SODIUM_EXPORT=__declspec(dllexport);DLL_EXPORT;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\..\..\src\libsodium\include\sodium;$(SolutionDir)..\..\..\src\libsodium\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_auth.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_auth_hmacsha256.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_auth_hmacsha512256.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_box.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_box_curve25519xsalsa20poly1305.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_core_hsalsa20.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_core_salsa20.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_core_salsa2012.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_core_salsa208.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_generichash_blake2b.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_hash.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_hashblocks_sha256.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_hashblocks_sha512.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_hash_sha256.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_hash_sha512.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_int32.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_int64.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_onetimeauth.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_onetimeauth_poly1305.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_scalarmult_curve25519.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_secretbox.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_secretbox_xsalsa20poly1305.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_shorthash.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_shorthash_siphash24.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_sign.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_sign_ed25519.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_sign_edwards25519sha512batch.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_aes128ctr.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_salsa20.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_salsa2012.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_salsa208.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_xsalsa20.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_uint16.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_uint32.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_uint64.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_uint8.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_verify_16.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_verify_32.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\randombytes.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\randombytes_salsa20_random.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\randombytes_sysrandom.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\utils.h" />
+    <ClInclude Include="..\version.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\hmacsha256\ref\hmac_hmacsha256.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\hmacsha256\ref\verify_hmacsha256.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\hmacsha512256\ref\hmac_hmacsha512256.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\hmacsha512256\ref\verify_hmacsha512256.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_box\curve25519xsalsa20poly1305\ref\after_curve25519xsalsa20poly1305.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_box\curve25519xsalsa20poly1305\ref\before_curve25519xsalsa20poly1305.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_box\curve25519xsalsa20poly1305\ref\box_curve25519xsalsa20poly1305.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_box\curve25519xsalsa20poly1305\ref\keypair_curve25519xsalsa20poly1305.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\hsalsa20\ref2\core_hsalsa20.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\salsa2012\ref\core_salsa2012.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\salsa208\ref\core_salsa208.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\salsa20\ref\core_salsa20.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_generichash\blake2\ref\blake2b-ref.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_generichash\blake2\ref\blake2s-ref.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_generichash\blake2\ref\generichash_blake2b.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_hashblocks\sha256\ref\blocks_sha256.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_hashblocks\sha512\ref\blocks_sha512.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_hash\sha256\ref\hash_sha256.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_hash\sha512\ref\hash_sha512.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_onetimeauth\poly1305\ref\auth_poly1305.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_onetimeauth\poly1305\ref\verify_poly1305.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_scalarmult\curve25519\ref\base.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_scalarmult\curve25519\ref\smult.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_secretbox\xsalsa20poly1305\ref\box_xsalsa20poly1305.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_shorthash\siphash24\ref\shorthash_siphash24.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_0.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_1.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_add.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_cmov.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_copy.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_frombytes.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_invert.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_isnegative.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_isnonzero.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_mul.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_neg.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_pow22523.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_sq.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_sq2.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_sub.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_tobytes.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_add.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_double_scalarmult.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_frombytes.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_madd.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_msub.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p1p1_to_p2.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p1p1_to_p3.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p2_0.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p2_dbl.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p3_0.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p3_dbl.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p3_tobytes.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p3_to_cached.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p3_to_p2.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_precomp_0.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_scalarmult_base.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_sub.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_tobytes.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\keypair.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\open.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\sc_muladd.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\sc_reduce.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\sign.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\afternm_aes128ctr.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\beforenm_aes128ctr.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\common_aes128ctr.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\consts_aes128ctr.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\int128_aes128ctr.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\stream_aes128ctr.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\xor_afternm_aes128ctr.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa2012\ref\stream_salsa2012.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa2012\ref\xor_salsa2012.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa208\ref\stream_salsa208.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa208\ref\xor_salsa208.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa20\ref\stream_salsa20.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa20\ref\xor_salsa20.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\xsalsa20\ref\stream_xsalsa20.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\xsalsa20\ref\xor_xsalsa20.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_verify\16\ref\verify_16.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_verify\32\ref\verify_32.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\randombytes\randombytes.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\randombytes\randombytes_salsa20_random.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\randombytes\randombytes_sysrandom.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\utils.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\version.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/dist-build/msvc/libsodium/libsodium/libsodium.vcxproj.filters
+++ b/dist-build/msvc/libsodium/libsodium/libsodium.vcxproj.filters
@@ -1,0 +1,414 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_auth.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_auth_hmacsha256.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_auth_hmacsha512256.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_box.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_box_curve25519xsalsa20poly1305.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_core_hsalsa20.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_core_salsa20.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_core_salsa208.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_core_salsa2012.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_generichash_blake2b.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_hash.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_hash_sha256.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_hash_sha512.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_hashblocks_sha256.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_hashblocks_sha512.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_int32.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_int64.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_onetimeauth.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_onetimeauth_poly1305.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_scalarmult_curve25519.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_secretbox.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_secretbox_xsalsa20poly1305.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_shorthash.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_shorthash_siphash24.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_sign.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_sign_ed25519.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_sign_edwards25519sha512batch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_aes128ctr.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_salsa20.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_salsa208.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_salsa2012.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_xsalsa20.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_uint8.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_uint16.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_uint32.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_uint64.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_verify_16.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_verify_32.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\randombytes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\randombytes_salsa20_random.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\randombytes_sysrandom.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\version.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\hmacsha256\ref\hmac_hmacsha256.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\hmacsha256\ref\verify_hmacsha256.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\hmacsha512256\ref\hmac_hmacsha512256.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\hmacsha512256\ref\verify_hmacsha512256.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_box\curve25519xsalsa20poly1305\ref\after_curve25519xsalsa20poly1305.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_box\curve25519xsalsa20poly1305\ref\before_curve25519xsalsa20poly1305.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_box\curve25519xsalsa20poly1305\ref\box_curve25519xsalsa20poly1305.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_box\curve25519xsalsa20poly1305\ref\keypair_curve25519xsalsa20poly1305.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\hsalsa20\ref2\core_hsalsa20.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\salsa20\ref\core_salsa20.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_generichash\blake2\ref\blake2b-ref.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_generichash\blake2\ref\blake2s-ref.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_generichash\blake2\ref\generichash_blake2b.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_hash\sha512\ref\hash_sha512.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_hash\sha256\ref\hash_sha256.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_hashblocks\sha256\ref\blocks_sha256.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_hashblocks\sha512\ref\blocks_sha512.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_onetimeauth\poly1305\ref\auth_poly1305.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_onetimeauth\poly1305\ref\verify_poly1305.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_scalarmult\curve25519\ref\base.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_scalarmult\curve25519\ref\smult.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_secretbox\xsalsa20poly1305\ref\box_xsalsa20poly1305.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_shorthash\siphash24\ref\shorthash_siphash24.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_0.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_1.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_add.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_cmov.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_copy.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_frombytes.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_invert.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_isnegative.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_isnonzero.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_mul.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_neg.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_pow22523.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_sq.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_sq2.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_sub.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\fe_tobytes.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_add.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_double_scalarmult.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_frombytes.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_madd.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_msub.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p1p1_to_p2.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p1p1_to_p3.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p2_0.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p2_dbl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p3_0.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p3_dbl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p3_to_cached.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p3_to_p2.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_p3_tobytes.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_precomp_0.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_scalarmult_base.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_sub.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\ge_tobytes.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\keypair.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\open.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\sc_muladd.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\sc_reduce.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_sign\ed25519\ref10\sign.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\afternm_aes128ctr.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\beforenm_aes128ctr.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\common_aes128ctr.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\consts_aes128ctr.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\int128_aes128ctr.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\stream_aes128ctr.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\aes128ctr\portable\xor_afternm_aes128ctr.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa20\ref\stream_salsa20.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa20\ref\xor_salsa20.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa208\ref\stream_salsa208.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa208\ref\xor_salsa208.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa2012\ref\stream_salsa2012.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\salsa2012\ref\xor_salsa2012.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\xsalsa20\ref\stream_xsalsa20.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_stream\xsalsa20\ref\xor_xsalsa20.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_verify\16\ref\verify_16.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_verify\32\ref\verify_32.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\utils.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\version.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\randombytes\randombytes.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\randombytes\randombytes_salsa20_random.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\randombytes\randombytes_sysrandom.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\salsa208\ref\core_salsa208.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\salsa2012\ref\core_salsa2012.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/dist-build/msvc/libsodium/version.h
+++ b/dist-build/msvc/libsodium/version.h
@@ -1,0 +1,25 @@
+
+#ifndef __SODIUM_VERSION_H__
+#define __SODIUM_VERSION_H__
+
+#define _STR(x) #x
+#define STR(x) _STR(x)
+
+#define SODIUM_VERSION_MAJOR 0
+#define SODIUM_VERSION_MINOR 4
+
+#define SODIUM_VERSION_STRING STR(SODIUM_VERSION_MAJOR) "." STR(SODIUM_VERSION_MINOR)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+SODIUM_EXPORT const char *sodium_version_string(void);
+SODIUM_EXPORT int         sodium_version_major(void);
+SODIUM_EXPORT int         sodium_version_minor(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/libsodium/crypto_generichash/blake2/ref/generichash_blake2b.c
+++ b/src/libsodium/crypto_generichash/blake2/ref/generichash_blake2b.c
@@ -18,8 +18,11 @@ crypto_generichash_blake2b(unsigned char *out, const unsigned char *in,
         inlen > UINT64_MAX) {
         return -1;
     }
+	/* The following is NOT a compile-time check! */
+	/*
     COMPILER_ASSERT(outlen <= UINT8_MAX);
     COMPILER_ASSERT(keylen <= UINT8_MAX);
+	*/
 
     return blake2b((uint8_t *) out, in, key,
                    (uint8_t) outlen, inlen, (uint8_t) keylen);

--- a/src/libsodium/include/sodium.h
+++ b/src/libsodium/include/sodium.h
@@ -2,6 +2,16 @@
 #ifndef sodium_H
 #define sodium_H
 
+#if defined(_MSC_VER) && !defined(SODIUM_STATIC)
+#	ifdef DLL_EXPORT
+#		define SODIUM_EXPORT __declspec(dllexport)
+#	else
+#		define SODIUM_EXPORT __declspec(dllimport) 
+#	endif
+#else
+#	define SODIUM_EXPORT
+#endif
+
 #include <sodium/crypto_auth.h>
 #include <sodium/crypto_auth_hmacsha256.h>
 #include <sodium/crypto_auth_hmacsha512256.h>

--- a/src/libsodium/include/sodium/crypto_auth_hmacsha256.h
+++ b/src/libsodium/include/sodium/crypto_auth_hmacsha256.h
@@ -6,8 +6,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_auth_hmacsha256_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
-extern int crypto_auth_hmacsha256_ref_verify(const unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_auth_hmacsha256_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_auth_hmacsha256_ref_verify(const unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_auth_hmacsha512256.h
+++ b/src/libsodium/include/sodium/crypto_auth_hmacsha512256.h
@@ -6,8 +6,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_auth_hmacsha512256_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
-extern int crypto_auth_hmacsha512256_ref_verify(const unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_auth_hmacsha512256_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_auth_hmacsha512256_ref_verify(const unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_box_curve25519xsalsa20poly1305.h
+++ b/src/libsodium/include/sodium/crypto_box_curve25519xsalsa20poly1305.h
@@ -10,12 +10,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_box_curve25519xsalsa20poly1305_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *,const unsigned char *);
-extern int crypto_box_curve25519xsalsa20poly1305_ref_open(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *,const unsigned char *);
-extern int crypto_box_curve25519xsalsa20poly1305_ref_keypair(unsigned char *,unsigned char *);
-extern int crypto_box_curve25519xsalsa20poly1305_ref_beforenm(unsigned char *,const unsigned char *,const unsigned char *);
-extern int crypto_box_curve25519xsalsa20poly1305_ref_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_box_curve25519xsalsa20poly1305_ref_open_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_box_curve25519xsalsa20poly1305_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_box_curve25519xsalsa20poly1305_ref_open(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_box_curve25519xsalsa20poly1305_ref_keypair(unsigned char *,unsigned char *);
+SODIUM_EXPORT extern int crypto_box_curve25519xsalsa20poly1305_ref_beforenm(unsigned char *,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_box_curve25519xsalsa20poly1305_ref_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_box_curve25519xsalsa20poly1305_ref_open_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_core_hsalsa20.h
+++ b/src/libsodium/include/sodium/crypto_core_hsalsa20.h
@@ -8,7 +8,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_core_hsalsa20_ref2(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_core_hsalsa20_ref2(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_core_salsa20.h
+++ b/src/libsodium/include/sodium/crypto_core_salsa20.h
@@ -8,7 +8,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_core_salsa20_ref(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_core_salsa20_ref(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_core_salsa2012.h
+++ b/src/libsodium/include/sodium/crypto_core_salsa2012.h
@@ -8,7 +8,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_core_salsa2012_ref(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_core_salsa2012_ref(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_core_salsa208.h
+++ b/src/libsodium/include/sodium/crypto_core_salsa208.h
@@ -8,7 +8,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_core_salsa208_ref(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_core_salsa208_ref(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_generichash_blake2b.h
+++ b/src/libsodium/include/sodium/crypto_generichash_blake2b.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include <stdlib.h>
     
-extern int crypto_generichash_blake2b_ref(unsigned char *out, const unsigned char *in,
+SODIUM_EXPORT extern int crypto_generichash_blake2b_ref(unsigned char *out, const unsigned char *in,
                                           const unsigned char *key,
                                           size_t outlen, unsigned long long inlen,
                                           size_t keylen);

--- a/src/libsodium/include/sodium/crypto_hash_sha256.h
+++ b/src/libsodium/include/sodium/crypto_hash_sha256.h
@@ -5,7 +5,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_hash_sha256_ref(unsigned char *,const unsigned char *,unsigned long long);
+SODIUM_EXPORT extern int crypto_hash_sha256_ref(unsigned char *,const unsigned char *,unsigned long long);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_hash_sha512.h
+++ b/src/libsodium/include/sodium/crypto_hash_sha512.h
@@ -5,7 +5,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_hash_sha512_ref(unsigned char *,const unsigned char *,unsigned long long);
+SODIUM_EXPORT extern int crypto_hash_sha512_ref(unsigned char *,const unsigned char *,unsigned long long);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_hashblocks_sha256.h
+++ b/src/libsodium/include/sodium/crypto_hashblocks_sha256.h
@@ -6,7 +6,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_hashblocks_sha256_ref(unsigned char *,const unsigned char *,unsigned long long);
+SODIUM_EXPORT extern int crypto_hashblocks_sha256_ref(unsigned char *,const unsigned char *,unsigned long long);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_hashblocks_sha512.h
+++ b/src/libsodium/include/sodium/crypto_hashblocks_sha512.h
@@ -6,7 +6,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_hashblocks_sha512_ref(unsigned char *,const unsigned char *,unsigned long long);
+SODIUM_EXPORT extern int crypto_hashblocks_sha512_ref(unsigned char *,const unsigned char *,unsigned long long);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_onetimeauth_poly1305.h
+++ b/src/libsodium/include/sodium/crypto_onetimeauth_poly1305.h
@@ -6,8 +6,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_onetimeauth_poly1305_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
-extern int crypto_onetimeauth_poly1305_ref_verify(const unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_onetimeauth_poly1305_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_onetimeauth_poly1305_ref_verify(const unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_scalarmult_curve25519.h
+++ b/src/libsodium/include/sodium/crypto_scalarmult_curve25519.h
@@ -6,8 +6,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_scalarmult_curve25519_ref(unsigned char *,const unsigned char *,const unsigned char *);
-extern int crypto_scalarmult_curve25519_ref_base(unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_scalarmult_curve25519_ref(unsigned char *,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_scalarmult_curve25519_ref_base(unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_secretbox_xsalsa20poly1305.h
+++ b/src/libsodium/include/sodium/crypto_secretbox_xsalsa20poly1305.h
@@ -8,8 +8,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_secretbox_xsalsa20poly1305_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_secretbox_xsalsa20poly1305_ref_open(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_secretbox_xsalsa20poly1305_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_secretbox_xsalsa20poly1305_ref_open(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_shorthash_siphash24.h
+++ b/src/libsodium/include/sodium/crypto_shorthash_siphash24.h
@@ -6,7 +6,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_shorthash_siphash24_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_shorthash_siphash24_ref(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_sign_ed25519.h
+++ b/src/libsodium/include/sodium/crypto_sign_ed25519.h
@@ -8,10 +8,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_sign_ed25519_ref10(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
-extern int crypto_sign_ed25519_ref10_open(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
-extern int crypto_sign_ed25519_ref10_keypair(unsigned char *,unsigned char *);
-extern int crypto_sign_ed25519_ref10_seed_keypair(unsigned char *,unsigned char *,unsigned char *);
+SODIUM_EXPORT extern int crypto_sign_ed25519_ref10(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_sign_ed25519_ref10_open(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_sign_ed25519_ref10_keypair(unsigned char *,unsigned char *);
+SODIUM_EXPORT extern int crypto_sign_ed25519_ref10_seed_keypair(unsigned char *,unsigned char *,unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_sign_edwards25519sha512batch.h
+++ b/src/libsodium/include/sodium/crypto_sign_edwards25519sha512batch.h
@@ -7,9 +7,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_sign_edwards25519sha512batch_ref(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
-extern int crypto_sign_edwards25519sha512batch_ref_open(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
-extern int crypto_sign_edwards25519sha512batch_ref_keypair(unsigned char *,unsigned char *);
+SODIUM_EXPORT extern int crypto_sign_edwards25519sha512batch_ref(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_sign_edwards25519sha512batch_ref_open(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
+SODIUM_EXPORT extern int crypto_sign_edwards25519sha512batch_ref_keypair(unsigned char *,unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_stream_aes128ctr.h
+++ b/src/libsodium/include/sodium/crypto_stream_aes128ctr.h
@@ -7,11 +7,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_stream_aes128ctr_portable(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_aes128ctr_portable_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_aes128ctr_portable_beforenm(unsigned char *,const unsigned char *);
-extern int crypto_stream_aes128ctr_portable_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_aes128ctr_portable_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_aes128ctr_portable(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_aes128ctr_portable_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_aes128ctr_portable_beforenm(unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_aes128ctr_portable_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_aes128ctr_portable_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_stream_salsa20.h
+++ b/src/libsodium/include/sodium/crypto_stream_salsa20.h
@@ -6,11 +6,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_stream_salsa20_ref(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa20_ref_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa20_ref_beforenm(unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa20_ref_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa20_ref_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa20_ref(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa20_ref_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa20_ref_beforenm(unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa20_ref_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa20_ref_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_stream_salsa2012.h
+++ b/src/libsodium/include/sodium/crypto_stream_salsa2012.h
@@ -6,11 +6,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_stream_salsa2012_ref(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa2012_ref_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa2012_ref_beforenm(unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa2012_ref_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa2012_ref_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa2012_ref(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa2012_ref_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa2012_ref_beforenm(unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa2012_ref_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa2012_ref_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_stream_salsa208.h
+++ b/src/libsodium/include/sodium/crypto_stream_salsa208.h
@@ -6,11 +6,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_stream_salsa208_ref(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa208_ref_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa208_ref_beforenm(unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa208_ref_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_salsa208_ref_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa208_ref(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa208_ref_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa208_ref_beforenm(unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa208_ref_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_salsa208_ref_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_stream_xsalsa20.h
+++ b/src/libsodium/include/sodium/crypto_stream_xsalsa20.h
@@ -6,11 +6,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_stream_xsalsa20_ref(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_xsalsa20_ref_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_xsalsa20_ref_beforenm(unsigned char *,const unsigned char *);
-extern int crypto_stream_xsalsa20_ref_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
-extern int crypto_stream_xsalsa20_ref_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_xsalsa20_ref(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_xsalsa20_ref_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_xsalsa20_ref_beforenm(unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_xsalsa20_ref_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_stream_xsalsa20_ref_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_verify_16.h
+++ b/src/libsodium/include/sodium/crypto_verify_16.h
@@ -5,7 +5,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_verify_16_ref(const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_verify_16_ref(const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_verify_32.h
+++ b/src/libsodium/include/sodium/crypto_verify_32.h
@@ -5,7 +5,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern int crypto_verify_32_ref(const unsigned char *,const unsigned char *);
+SODIUM_EXPORT extern int crypto_verify_32_ref(const unsigned char *,const unsigned char *);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/randombytes.h
+++ b/src/libsodium/include/sodium/randombytes.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #include <sys/types.h>
 
-#include <inttypes.h>
+#include <stdint.h>
 #include <stdio.h>
 
 typedef struct randombytes_implementation {
@@ -20,16 +20,16 @@ typedef struct randombytes_implementation {
     int         (*randombytes_close)(void);
 } randombytes_implementation;
 
-int         randombytes_set_implementation(randombytes_implementation *impl);
+SODIUM_EXPORT int         randombytes_set_implementation(randombytes_implementation *impl);
 
-void        randombytes(unsigned char *buf, unsigned long long size);
+SODIUM_EXPORT void        randombytes(unsigned char *buf, unsigned long long size);
 
-const char *randombytes_implementation_name(void);
-uint32_t    randombytes_random(void);
-void        randombytes_stir(void);
-uint32_t    randombytes_uniform(const uint32_t upper_bound);
-void        randombytes_buf(void * const buf, const size_t size);
-int         randombytes_close(void);
+SODIUM_EXPORT const char *randombytes_implementation_name(void);
+SODIUM_EXPORT uint32_t    randombytes_random(void);
+SODIUM_EXPORT void        randombytes_stir(void);
+SODIUM_EXPORT uint32_t    randombytes_uniform(const uint32_t upper_bound);
+SODIUM_EXPORT void        randombytes_buf(void * const buf, const size_t size);
+SODIUM_EXPORT int         randombytes_close(void);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/randombytes_salsa20_random.h
+++ b/src/libsodium/include/sodium/randombytes_salsa20_random.h
@@ -9,13 +9,13 @@
 extern "C" {
 #endif
 
-const char *salsa20_random_implementation_name(void);
+SODIUM_EXPORT const char *salsa20_random_implementation_name(void);
 
-uint32_t    salsa20_random(void);
-void        salsa20_random_stir(void);
-uint32_t    salsa20_random_uniform(const uint32_t upper_bound);
-void        salsa20_random_buf(void * const buf, const size_t size);
-int         salsa20_random_close(void);
+SODIUM_EXPORT uint32_t    salsa20_random(void);
+SODIUM_EXPORT void        salsa20_random_stir(void);
+SODIUM_EXPORT uint32_t    salsa20_random_uniform(const uint32_t upper_bound);
+SODIUM_EXPORT void        salsa20_random_buf(void * const buf, const size_t size);
+SODIUM_EXPORT int         salsa20_random_close(void);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/randombytes_sysrandom.h
+++ b/src/libsodium/include/sodium/randombytes_sysrandom.h
@@ -9,13 +9,13 @@
 extern "C" {
 #endif
 
-const char *sysrandom_implementation_name(void);
+SODIUM_EXPORT const char *sysrandom_implementation_name(void);
 
-uint32_t    sysrandom(void);
-void        sysrandom_stir(void);
-uint32_t    sysrandom_uniform(const uint32_t upper_bound);
-void        sysrandom_buf(void * const buf, const size_t size);
-int         sysrandom_close(void);
+SODIUM_EXPORT uint32_t    sysrandom(void);
+SODIUM_EXPORT void        sysrandom_stir(void);
+SODIUM_EXPORT uint32_t    sysrandom_uniform(const uint32_t upper_bound);
+SODIUM_EXPORT void        sysrandom_buf(void * const buf, const size_t size);
+SODIUM_EXPORT int         sysrandom_close(void);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/utils.h
+++ b/src/libsodium/include/sodium/utils.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-void sodium_memzero(void * const pnt, const size_t size);
+SODIUM_EXPORT void sodium_memzero(void * const pnt, const size_t size);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/randombytes/randombytes.c
+++ b/src/libsodium/randombytes/randombytes.c
@@ -8,12 +8,12 @@
 #include "randombytes_sysrandom.h"
 
 static randombytes_implementation implementation = {
-    .randombytes_implementation_name = sysrandom_implementation_name,
-    .randombytes_random = sysrandom,
-    .randombytes_stir = sysrandom_stir,
-    .randombytes_uniform = sysrandom_uniform,
-    .randombytes_buf = sysrandom_buf,
-    .randombytes_close = sysrandom_close
+    /*.randombytes_implementation_name =*/ sysrandom_implementation_name,
+    /*.randombytes_random =*/ sysrandom,
+    /*.randombytes_stir =*/ sysrandom_stir,
+    /*.randombytes_uniform =*/ sysrandom_uniform,
+    /*.randombytes_buf =*/ sysrandom_buf,
+    /*.randombytes_close =*/ sysrandom_close
 };
 
 int


### PR DESCRIPTION
This pull request adds support for Microsoft Visual Studio 2010 and 2012. 

Changes:
- Added a VS project on dist-build/msvc
- Some minor changes to enable MSVC compilation (where possible these are guarded by #ifdef _MSC_VER)
- Added the SODIUM_STATIC macro. If this macro is defined, then SODIUM_EXPORT is empty and static linking is assumed. Otherwise, SODIUM_EXPORT is __declspec(dllimport) and dynamic linking is assumed. This only matters when using MSVC.

To maintain compatibility with the above changes, the regular autotools build system is only required to define the empty macro SODIUM_EXPORT.
