### PR TITLE
always_inline warnings

### DIFF
--- a/src/libsodium/crypto_scalarmult/curve25519/donna_c64/smult_curve25519_donna_c64.c
+++ b/src/libsodium/crypto_scalarmult/curve25519/donna_c64/smult_curve25519_donna_c64.c
@@ -36,7 +36,7 @@ typedef limb felem[5];
 typedef unsigned uint128_t __attribute__((mode(TI)));
 
 #undef force_inline
-#define force_inline __attribute__((always_inline))
+#define force_inline inline __attribute__((always_inline))
 
 /* Sum two numbers: output += in */
 static void force_inline


### PR DESCRIPTION
The "**attribute**((always_inline))" attribute does not replace "inline", they need to be used together. This fixes the "warning: always_inline function might not be inlinable [-Wattributes]" warnings emitted by GCC 4.7.
