### PR TITLE
Add a crypto_sign_SEEDBYTES macro/getter and associated ed25519 macro/getter

### DIFF
--- a/src/libsodium/crypto_sign/crypto_sign.c
+++ b/src/libsodium/crypto_sign/crypto_sign.c
@@ -8,6 +8,12 @@ crypto_sign_bytes(void)
 }
 
 size_t
+crypto_sign_seedbytes(void)
+{
+    return crypto_sign_SEEDBYTES;
+}
+
+size_t
 crypto_sign_publickeybytes(void)
 {
     return crypto_sign_PUBLICKEYBYTES;

--- a/src/libsodium/crypto_sign/ed25519/ref10/api.h
+++ b/src/libsodium/crypto_sign/ed25519/ref10/api.h
@@ -6,6 +6,7 @@
 #define crypto_sign_keypair crypto_sign_ed25519_keypair
 #define crypto_sign_seed_keypair crypto_sign_ed25519_seed_keypair
 #define crypto_sign_BYTES crypto_sign_ed25519_BYTES
+#define crypto_sign_SEEDBYTES crypto_sign_ed25519_SEEDBYTES
 #define crypto_sign_PUBLICKEYBYTES crypto_sign_ed25519_PUBLICKEYBYTES
 #define crypto_sign_SECRETKEYBYTES crypto_sign_ed25519_SECRETKEYBYTES
 #define crypto_sign_PRIMITIVE "ed25519"

--- a/src/libsodium/crypto_sign/ed25519/sign_ed25519_api.c
+++ b/src/libsodium/crypto_sign/ed25519/sign_ed25519_api.c
@@ -6,6 +6,11 @@ crypto_sign_ed25519_bytes(void) {
 }
 
 size_t
+crypto_sign_ed25519_seedbytes(void) {
+    return crypto_sign_ed25519_SEEDBYTES;
+}
+
+size_t
 crypto_sign_ed25519_publickeybytes(void) {
     return crypto_sign_ed25519_PUBLICKEYBYTES;
 }

--- a/src/libsodium/include/sodium/crypto_sign.h
+++ b/src/libsodium/include/sodium/crypto_sign.h
@@ -21,6 +21,10 @@ extern "C" {
 SODIUM_EXPORT
 size_t  crypto_sign_bytes(void);
 
+#define crypto_sign_SEEDBYTES crypto_sign_ed25519_SEEDBYTES
+SODIUM_EXPORT
+size_t  crypto_sign_seedbytes(void);
+
 #define crypto_sign_PUBLICKEYBYTES crypto_sign_ed25519_PUBLICKEYBYTES
 SODIUM_EXPORT
 size_t  crypto_sign_publickeybytes(void);

--- a/src/libsodium/include/sodium/crypto_sign_ed25519.h
+++ b/src/libsodium/include/sodium/crypto_sign_ed25519.h
@@ -6,6 +6,7 @@
 
 #define crypto_sign_ed25519_SECRETKEYBYTES 64U
 #define crypto_sign_ed25519_PUBLICKEYBYTES 32U
+#define crypto_sign_ed25519_SEEDBYTES 32U
 #define crypto_sign_ed25519_BYTES 64U
 
 #ifdef __cplusplus
@@ -14,6 +15,9 @@ extern "C" {
 
 SODIUM_EXPORT
 size_t crypto_sign_ed25519_bytes(void);
+
+SODIUM_EXPORT
+size_t crypto_sign_ed25519_seedbytes(void);
 
 SODIUM_EXPORT
 size_t crypto_sign_ed25519_publickeybytes(void);


### PR DESCRIPTION
This patch provides a macro and a getter corresponding to the expected size of the seed provided to crypto_sign_seed_keypair.
