### PR TITLE
Add stackmarkings to stream_salsa20_amd64_xmm6.s

### DIFF
--- a/src/libsodium/crypto_stream/salsa20/amd64_xmm6/stream_salsa20_amd64_xmm6.s
+++ b/src/libsodium/crypto_stream/salsa20/amd64_xmm6/stream_salsa20_amd64_xmm6.s
@@ -1,4 +1,3 @@
-
 #if defined(__amd64) || defined(__amd64__) || defined(__x86_64__)
 
 .text
@@ -944,4 +943,8 @@ add  $64,%rdi
 add  $64,%rsi
 jmp ._bytesbetween1and255
 
+#endif
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
 #endif


### PR DESCRIPTION
I'm trying to package libsodium for gentoo and received this warning:
- !WX --- --- usr/lib64/libsodium.a:stream_salsa20_amd64_xmm6.o

According to http://www.gentoo.org/proj/en/hardened/gnu-stack.xml
this commit fixes it.

Please handle this with care, as I am no asm guru.
