### PR TITLE
build: create and install a pkgconfig file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,3 +9,6 @@ EXTRA_DIST = \
 SUBDIRS = \
 	src \
 	test
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = @PACKAGE_NAME@.pc

--- a/configure.ac
+++ b/configure.ac
@@ -362,6 +362,7 @@ AH_VERBATIM([NDEBUG], [/* Never ever ignore assertions */
 #/**/undef/**/ NDEBUG
 #endif])
 
+AC_CONFIG_FILES([libsodium.pc])
 AC_CONFIG_FILES([Makefile
                  src/Makefile
                  src/libsodium/Makefile

--- a/libsodium.pc.in
+++ b/libsodium.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Version: @PACKAGE_VERSION@
+Description: A portable, cross-compilable, installable, packageable fork of NaCl, with a compatible API.
+
+Libs: -L${libdir} -lsodium
+Cflags: -I${includedir}


### PR DESCRIPTION
This adds trivial changes to the autotools infrastructur and a
template to generate and install a pkgconfig file libsodium.pc.
