### PR TITLE
build: add -std=c99 as default CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,9 @@ AC_SUBST(DLL_VERSION)
 
 LX_CFLAGS=${CFLAGS-NONE}
 
+# default CFLAGS
+CFLAGS="-std=c99"
+
 dnl Switches
 
 AC_ARG_ENABLE(ssp,


### PR DESCRIPTION
We need to inject '-std=c99' because the reference implementation of blake2
is using C99 specific semantics.

---

crypto_generichash/blake2/ref/blake2b-ref.c: In function 'blake2b_init0':
crypto_generichash/blake2/ref/blake2b-ref.c:143:3: error: 'for' loop initial declarations are only allowed in C99 mode
crypto_generichash/blake2/ref/blake2b-ref.c:143:3: note: use option -std=c99 or -std=gnu99 to compile your code
crypto_generichash/blake2/ref/blake2b-ref.c: In function 'crypto_generichash_blake2b__init_param':
crypto_generichash/blake2/ref/blake2b-ref.c:155:3: error: 'for' loop initial declarations are only allowed in C99 mode
crypto_generichash/blake2/ref/blake2b-ref.c: In function 'crypto_generichash_blake2b__final':
## crypto_generichash/blake2/ref/blake2b-ref.c:328:3: error: 'for' loop initial declarations are only allowed in C99 mode
