### PR TITLE
build: changed to only generate/install .pc file if pkg-config is found

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,5 +10,7 @@ SUBDIRS = \
 	src \
 	test
 
+if HAVE_PKG_CONFIG
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = @PACKAGE_NAME@.pc
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,10 @@ AC_SUBST([MAINT])
 
 dnl Checks
 
+PKG_PROG_PKG_CONFIG([0.25])
+AM_CONDITIONAL([HAVE_PKG_CONFIG], [test "x$PKG_CONFIG" != "x"])
+AC_SUBST(HAVE_PKG_CONFIG)
+
 AC_PROG_CC_C99
 AM_PROG_AS
 AC_USE_SYSTEM_EXTENSIONS
@@ -365,7 +369,9 @@ AH_VERBATIM([NDEBUG], [/* Never ever ignore assertions */
 #/**/undef/**/ NDEBUG
 #endif])
 
-AC_CONFIG_FILES([libsodium.pc])
+AS_IF([test "x$PKG_CONFIG" != "x"], [
+  AC_CONFIG_FILES([libsodium.pc])
+])
 AC_CONFIG_FILES([Makefile
                  src/Makefile
                  src/libsodium/Makefile


### PR DESCRIPTION
This change improves the pkg-config support to only generate/install a .pc
file if pkg-config is found, assuming it is part of the build toolchain.

Note:

The minimal version set for pkg-config is 0.25, because this is the oldest
version I am able to test at the moment.
