### PR TITLE
Fix compilation warnings (GCC 4.7)

### DIFF
--- a/src/libsodium/crypto_generichash/blake2/ref/blake2-impl.h
+++ b/src/libsodium/crypto_generichash/blake2/ref/blake2-impl.h
@@ -23,7 +23,7 @@ static inline uint32_t load32( const void *src )
 #if defined(NATIVE_LITTLE_ENDIAN)
   return *( uint32_t * )( src );
 #else
-  const uint8_t *p = ( uint8_t * )src;
+  const uint8_t *p = ( const uint8_t * )src;
   uint32_t w = *p++;
   w |= ( uint32_t )( *p++ ) <<  8;
   w |= ( uint32_t )( *p++ ) << 16;
@@ -37,7 +37,7 @@ static inline uint64_t load64( const void *src )
 #if defined(NATIVE_LITTLE_ENDIAN)
   return *( uint64_t * )( src );
 #else
-  const uint8_t *p = ( uint8_t * )src;
+  const uint8_t *p = ( const uint8_t * )src;
   uint64_t w = *p++;
   w |= ( uint64_t )( *p++ ) <<  8;
   w |= ( uint64_t )( *p++ ) << 16;

--- a/src/libsodium/crypto_generichash/blake2/ref/blake2b-ref.c
+++ b/src/libsodium/crypto_generichash/blake2/ref/blake2b-ref.c
@@ -149,7 +149,7 @@ static inline int blake2b_init0( blake2b_state *S )
 int blake2b_init_param( blake2b_state *S, const blake2b_param *P )
 {
   blake2b_init0( S );
-  uint8_t *p = ( uint8_t * )( P );
+  const uint8_t *p = ( const uint8_t * )( P );
 
   /* IV XOR ParamBlock */
   for( size_t i = 0; i < 8; ++i )
@@ -353,7 +353,7 @@ int blake2b( uint8_t *out, const void *in, const void *key, const uint8_t outlen
     if( blake2b_init( S, outlen ) < 0 ) return -1;
   }
 
-  blake2b_update( S, ( uint8_t * )in, inlen );
+  blake2b_update( S, ( const uint8_t * )in, inlen );
   blake2b_final( S, out, outlen );
   return 0;
 }

--- a/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c
+++ b/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c
@@ -251,30 +251,30 @@ int crypto_onetimeauth(unsigned char *out,const unsigned char *m,unsigned long l
   }
 #endif
 
-  r00 = *(uchar *) (r + 0);
+  r00 = *(const uchar *) (r + 0);
   constants = (char *) &poly1305_53_constants;
 
-  r01 = *(uchar *) (r + 1);
+  r01 = *(const uchar *) (r + 1);
 
-  r02 = *(uchar *) (r + 2);
+  r02 = *(const uchar *) (r + 2);
   r0 = 2151;
 
-  r03 = *(uchar *) (r + 3); r03 &= 15;
+  r03 = *(const uchar *) (r + 3); r03 &= 15;
   r0 <<= 51;
 
-  r10 = *(uchar *) (r + 4); r10 &= 252;
+  r10 = *(const uchar *) (r + 4); r10 &= 252;
   r01 <<= 8;
   r0 += r00;
 
-  r11 = *(uchar *) (r + 5);
+  r11 = *(const uchar *) (r + 5);
   r02 <<= 16;
   r0 += r01;
 
-  r12 = *(uchar *) (r + 6);
+  r12 = *(const uchar *) (r + 6);
   r03 <<= 24;
   r0 += r02;
 
-  r13 = *(uchar *) (r + 7); r13 &= 15;
+  r13 = *(const uchar *) (r + 7); r13 &= 15;
   r1 = 2215;
   r0 += r03;
 
@@ -282,19 +282,19 @@ int crypto_onetimeauth(unsigned char *out,const unsigned char *m,unsigned long l
   r1 <<= 51;
   r2 = 2279;
 
-  r20 = *(uchar *) (r + 8); r20 &= 252;
+  r20 = *(const uchar *) (r + 8); r20 &= 252;
   r11 <<= 8;
   r1 += r10;
 
-  r21 = *(uchar *) (r + 9);
+  r21 = *(const uchar *) (r + 9);
   r12 <<= 16;
   r1 += r11;
 
-  r22 = *(uchar *) (r + 10);
+  r22 = *(const uchar *) (r + 10);
   r13 <<= 24;
   r1 += r12;
 
-  r23 = *(uchar *) (r + 11); r23 &= 15;
+  r23 = *(const uchar *) (r + 11); r23 &= 15;
   r2 <<= 51;
   r1 += r13;
 
@@ -302,15 +302,15 @@ int crypto_onetimeauth(unsigned char *out,const unsigned char *m,unsigned long l
   r21 <<= 8;
   r2 += r20;
 
-  r30 = *(uchar *) (r + 12); r30 &= 252;
+  r30 = *(const uchar *) (r + 12); r30 &= 252;
   r22 <<= 16;
   r2 += r21;
 
-  r31 = *(uchar *) (r + 13);
+  r31 = *(const uchar *) (r + 13);
   r23 <<= 24;
   r2 += r22;
 
-  r32 = *(uchar *) (r + 14);
+  r32 = *(const uchar *) (r + 14);
   r2 += r23;
   r3 = 2343;
 
@@ -318,7 +318,7 @@ int crypto_onetimeauth(unsigned char *out,const unsigned char *m,unsigned long l
   r3 <<= 51;
   alpha32 = *(double *) (constants + 40);
 
-  r33 = *(uchar *) (r + 15); r33 &= 15;
+  r33 = *(const uchar *) (r + 15); r33 &= 15;
   r31 <<= 8;
   r3 += r30;
 
@@ -435,65 +435,65 @@ int crypto_onetimeauth(unsigned char *out,const unsigned char *m,unsigned long l
 
 if (l < 16) goto addatmost15bytes;
 
-  m00 = *(uchar *) (m + 0);
+  m00 = *(const uchar *) (m + 0);
   m0 = 2151;
 
   m0 <<= 51;
   m1 = 2215;
-  m01 = *(uchar *) (m + 1);
+  m01 = *(const uchar *) (m + 1);
 
   m1 <<= 51;
   m2 = 2279;
-  m02 = *(uchar *) (m + 2);
+  m02 = *(const uchar *) (m + 2);
 
   m2 <<= 51;
   m3 = 2343;
-  m03 = *(uchar *) (m + 3);
+  m03 = *(const uchar *) (m + 3);
 
-  m10 = *(uchar *) (m + 4);
+  m10 = *(const uchar *) (m + 4);
   m01 <<= 8;
   m0 += m00;
 
-  m11 = *(uchar *) (m + 5);
+  m11 = *(const uchar *) (m + 5);
   m02 <<= 16;
   m0 += m01;
 
-  m12 = *(uchar *) (m + 6);
+  m12 = *(const uchar *) (m + 6);
   m03 <<= 24;
   m0 += m02;
 
-  m13 = *(uchar *) (m + 7);
+  m13 = *(const uchar *) (m + 7);
   m3 <<= 51;
   m0 += m03;
 
-  m20 = *(uchar *) (m + 8);
+  m20 = *(const uchar *) (m + 8);
   m11 <<= 8;
   m1 += m10;
 
-  m21 = *(uchar *) (m + 9);
+  m21 = *(const uchar *) (m + 9);
   m12 <<= 16;
   m1 += m11;
 
-  m22 = *(uchar *) (m + 10);
+  m22 = *(const uchar *) (m + 10);
   m13 <<= 24;
   m1 += m12;
 
-  m23 = *(uchar *) (m + 11);
+  m23 = *(const uchar *) (m + 11);
   m1 += m13;
 
-  m30 = *(uchar *) (m + 12);
+  m30 = *(const uchar *) (m + 12);
   m21 <<= 8;
   m2 += m20;
 
-  m31 = *(uchar *) (m + 13);
+  m31 = *(const uchar *) (m + 13);
   m22 <<= 16;
   m2 += m21;
 
-  m32 = *(uchar *) (m + 14);
+  m32 = *(const uchar *) (m + 14);
   m23 <<= 24;
   m2 += m22;
 
-  m33 = *(uchar *) (m + 15);
+  m33 = *(const uchar *) (m + 15);
   m2 += m23;
 
   d0 = m0;
@@ -545,80 +545,80 @@ if (l < 16) goto multiplyaddatmost15bytes;
 multiplyaddatleast16bytes:;
 
   m2 = 2279;
-  m20 = *(uchar *) (m + 8);
+  m20 = *(const uchar *) (m + 8);
   y7 = h7 + alpha130;
 
   m2 <<= 51;
   m3 = 2343;
-  m21 = *(uchar *) (m + 9);
+  m21 = *(const uchar *) (m + 9);
   y6 = h6 + alpha130;
 
   m3 <<= 51;
   m0 = 2151;
-  m22 = *(uchar *) (m + 10);
+  m22 = *(const uchar *) (m + 10);
   y1 = h1 + alpha32;
 
   m0 <<= 51;
   m1 = 2215;
-  m23 = *(uchar *) (m + 11);
+  m23 = *(const uchar *) (m + 11);
   y0 = h0 + alpha32;
 
   m1 <<= 51;
-  m30 = *(uchar *) (m + 12);
+  m30 = *(const uchar *) (m + 12);
   y7 -= alpha130;
 
   m21 <<= 8;
   m2 += m20;
-  m31 = *(uchar *) (m + 13);
+  m31 = *(const uchar *) (m + 13);
   y6 -= alpha130;
 
   m22 <<= 16;
   m2 += m21;
-  m32 = *(uchar *) (m + 14);
+  m32 = *(const uchar *) (m + 14);
   y1 -= alpha32;
 
   m23 <<= 24;
   m2 += m22;
-  m33 = *(uchar *) (m + 15);
+  m33 = *(const uchar *) (m + 15);
   y0 -= alpha32;
 
   m2 += m23;
-  m00 = *(uchar *) (m + 0);
+  m00 = *(const uchar *) (m + 0);
   y5 = h5 + alpha96;
 
   m31 <<= 8;
   m3 += m30;
-  m01 = *(uchar *) (m + 1);
+  m01 = *(const uchar *) (m + 1);
   y4 = h4 + alpha96;
 
   m32 <<= 16;
-  m02 = *(uchar *) (m + 2);
+  m02 = *(const uchar *) (m + 2);
   x7 = h7 - y7;
   y7 *= scale;
 
   m33 += 256;
-  m03 = *(uchar *) (m + 3);
+  m03 = *(const uchar *) (m + 3);
   x6 = h6 - y6;
   y6 *= scale;
 
   m33 <<= 24;
   m3 += m31;
-  m10 = *(uchar *) (m + 4);
+  m10 = *(const uchar *) (m + 4);
   x1 = h1 - y1;
 
   m01 <<= 8;
   m3 += m32;
-  m11 = *(uchar *) (m + 5);
+  m11 = *(const uchar *) (m + 5);
   x0 = h0 - y0;
 
   m3 += m33;
   m0 += m00;
-  m12 = *(uchar *) (m + 6);
+  m12 = *(const uchar *) (m + 6);
   y5 -= alpha96;
 
   m02 <<= 16;
   m0 += m01;
-  m13 = *(uchar *) (m + 7);
+  m13 = *(const uchar *) (m + 7);
   y4 -= alpha96;
 
   m03 <<= 24;
@@ -977,19 +977,19 @@ if (l == 0) goto nomorebytes;
   lbelow2 >>= 31;
   lbelow4 = l - 4;
 
-  m00 = *(uchar *) (m + 0);
+  m00 = *(const uchar *) (m + 0);
   lbelow3 >>= 31;
   m += lbelow2;
 
-  m01 = *(uchar *) (m + 1);
+  m01 = *(const uchar *) (m + 1);
   lbelow4 >>= 31;
   m += lbelow3;
 
-  m02 = *(uchar *) (m + 2);
+  m02 = *(const uchar *) (m + 2);
   m += lbelow4;
   m0 = 2151;
 
-  m03 = *(uchar *) (m + 3);
+  m03 = *(const uchar *) (m + 3);
   m0 <<= 51;
   m1 = 2215;
 
@@ -1026,19 +1026,19 @@ if (l == 0) goto nomorebytes;
   lbelow6 >>= 31;
   m += lbelow5;
 
-  m10 = *(uchar *) (m + 4);
+  m10 = *(const uchar *) (m + 4);
   lbelow7 >>= 31;
   m += lbelow6;
 
-  m11 = *(uchar *) (m + 5);
+  m11 = *(const uchar *) (m + 5);
   lbelow8 >>= 31;
   m += lbelow7;
 
-  m12 = *(uchar *) (m + 6);
+  m12 = *(const uchar *) (m + 6);
   m1 <<= 51;
   m += lbelow8;
 
-  m13 = *(uchar *) (m + 7);
+  m13 = *(const uchar *) (m + 7);
   m10 &= ~lbelow5;
   lbelow4 -= lbelow5;
 
@@ -1081,19 +1081,19 @@ if (l == 0) goto nomorebytes;
   lbelow10 >>= 31;
   m += lbelow9;
 
-  m20 = *(uchar *) (m + 8);
+  m20 = *(const uchar *) (m + 8);
   lbelow11 >>= 31;
   m += lbelow10;
 
-  m21 = *(uchar *) (m + 9);
+  m21 = *(const uchar *) (m + 9);
   lbelow12 >>= 31;
   m += lbelow11;
 
-  m22 = *(uchar *) (m + 10);
+  m22 = *(const uchar *) (m + 10);
   m2 <<= 51;
   m += lbelow12;
 
-  m23 = *(uchar *) (m + 11);
+  m23 = *(const uchar *) (m + 11);
   m20 &= ~lbelow9;
   lbelow8 -= lbelow9;
 
@@ -1131,15 +1131,15 @@ if (l == 0) goto nomorebytes;
   m += lbelow13;
   lbelow15 = l - 15;
 
-  m30 = *(uchar *) (m + 12);
+  m30 = *(const uchar *) (m + 12);
   lbelow15 >>= 31;
   m += lbelow14;
 
-  m31 = *(uchar *) (m + 13);
+  m31 = *(const uchar *) (m + 13);
   m += lbelow15;
   m2 += m23;
 
-  m32 = *(uchar *) (m + 14);
+  m32 = *(const uchar *) (m + 14);
   m30 &= ~lbelow13;
   lbelow12 -= lbelow13;
 
@@ -1516,66 +1516,66 @@ nomorebytes:;
   g4 = f4 + g;
 
   g4 = g4 - 4;
-  s00 = *(uchar *) (s + 0);
+  s00 = *(const uchar *) (s + 0);
 
   f = (int64) g4 >> 63;
-  s01 = *(uchar *) (s + 1);
+  s01 = *(const uchar *) (s + 1);
 
   f0 &= f;
   g0 &= ~f;
-  s02 = *(uchar *) (s + 2);
+  s02 = *(const uchar *) (s + 2);
 
   f1 &= f;
   f0 |= g0;
-  s03 = *(uchar *) (s + 3);
+  s03 = *(const uchar *) (s + 3);
 
   g1 &= ~f;
   f2 &= f;
-  s10 = *(uchar *) (s + 4);
+  s10 = *(const uchar *) (s + 4);
 
   f3 &= f;
   g2 &= ~f;
-  s11 = *(uchar *) (s + 5);
+  s11 = *(const uchar *) (s + 5);
 
   g3 &= ~f;
   f1 |= g1;
-  s12 = *(uchar *) (s + 6);
+  s12 = *(const uchar *) (s + 6);
 
   f2 |= g2;
   f3 |= g3;
-  s13 = *(uchar *) (s + 7);
+  s13 = *(const uchar *) (s + 7);
 
   s01 <<= 8;
   f0 += s00;
-  s20 = *(uchar *) (s + 8);
+  s20 = *(const uchar *) (s + 8);
 
   s02 <<= 16;
   f0 += s01;
-  s21 = *(uchar *) (s + 9);
+  s21 = *(const uchar *) (s + 9);
 
   s03 <<= 24;
   f0 += s02;
-  s22 = *(uchar *) (s + 10);
+  s22 = *(const uchar *) (s + 10);
 
   s11 <<= 8;
   f1 += s10;
-  s23 = *(uchar *) (s + 11);
+  s23 = *(const uchar *) (s + 11);
 
   s12 <<= 16;
   f1 += s11;
-  s30 = *(uchar *) (s + 12);
+  s30 = *(const uchar *) (s + 12);
 
   s13 <<= 24;
   f1 += s12;
-  s31 = *(uchar *) (s + 13);
+  s31 = *(const uchar *) (s + 13);
 
   f0 += s03;
   f1 += s13;
-  s32 = *(uchar *) (s + 14);
+  s32 = *(const uchar *) (s + 14);
 
   s21 <<= 8;
   f2 += s20;
-  s33 = *(uchar *) (s + 15);
+  s33 = *(const uchar *) (s + 15);
 
   s22 <<= 16;
   f2 += s21;

--- a/src/libsodium/crypto_sign/edwards25519sha512batch/ref/ge25519_edwards25519sha512batch.c
+++ b/src/libsodium/crypto_sign/edwards25519sha512batch/ref/ge25519_edwards25519sha512batch.c
@@ -155,7 +155,7 @@ void ge25519_add(ge25519_p3 *r, const ge25519_p3 *p, const ge25519_p3 *q)
 void ge25519_double(ge25519_p3 *r, const ge25519_p3 *p)
 {
   ge25519_p1p1 grp1p1;
-  dbl_p1p1(&grp1p1, (ge25519_p2 *)p);
+  dbl_p1p1(&grp1p1, (const ge25519_p2 *)p);
   p1p1_to_p3(r, &grp1p1);
 }
 

--- a/src/libsodium/crypto_stream/aes128ctr/portable/afternm_aes128ctr.c
+++ b/src/libsodium/crypto_stream/aes128ctr/portable/afternm_aes128ctr.c
@@ -37,7 +37,7 @@ int crypto_stream_afternm(unsigned char *outp, unsigned long long len, const uns
   uint32 tmp;
 
   /* Copy nonce on the stack */
-  copy2(&nonce_stack, (int128 *) (noncep + 0));
+  copy2(&nonce_stack, (const int128 *) (noncep + 0));
   unsigned char *np = (unsigned char *)&nonce_stack;
 
     enc_block:

--- a/src/libsodium/crypto_stream/aes128ctr/portable/common.h
+++ b/src/libsodium/crypto_stream/aes128ctr/portable/common.h
@@ -370,7 +370,7 @@ void store64_littleendian(unsigned char *x,uint64 u);
 /* Macros used in multiple contexts */
 
 #define bitslicekey0(key, bskey) \
-  xmm0 = *(int128 *) (key + 0);\
+  xmm0 = *(const int128 *) (key + 0);\
   shufb(&xmm0, M0);\
   copy2(&xmm1, &xmm0);\
   copy2(&xmm2, &xmm0);\
@@ -480,21 +480,21 @@ void store64_littleendian(unsigned char *x,uint64 u);
 /* Macros used for encryption (and decryption) */
 
 #define shiftrows(x0, x1, x2, x3, x4, x5, x6, x7, i, M, bskey) \
-        xor2(&x0, (int128 *)(bskey + 128*(i-1) + 0));\
+        xor2(&x0, (const int128 *)(bskey + 128*(i-1) + 0));\
   shufb(&x0, M);\
-        xor2(&x1, (int128 *)(bskey + 128*(i-1) + 16));\
+        xor2(&x1, (const int128 *)(bskey + 128*(i-1) + 16));\
   shufb(&x1, M);\
-        xor2(&x2, (int128 *)(bskey + 128*(i-1) + 32));\
+        xor2(&x2, (const int128 *)(bskey + 128*(i-1) + 32));\
   shufb(&x2, M);\
-        xor2(&x3, (int128 *)(bskey + 128*(i-1) + 48));\
+        xor2(&x3, (const int128 *)(bskey + 128*(i-1) + 48));\
   shufb(&x3, M);\
-        xor2(&x4, (int128 *)(bskey + 128*(i-1) + 64));\
+        xor2(&x4, (const int128 *)(bskey + 128*(i-1) + 64));\
   shufb(&x4, M);\
-        xor2(&x5, (int128 *)(bskey + 128*(i-1) + 80));\
+        xor2(&x5, (const int128 *)(bskey + 128*(i-1) + 80));\
   shufb(&x5, M);\
-        xor2(&x6, (int128 *)(bskey + 128*(i-1) + 96));\
+        xor2(&x6, (const int128 *)(bskey + 128*(i-1) + 96));\
   shufb(&x6, M);\
-        xor2(&x7, (int128 *)(bskey + 128*(i-1) + 112));\
+        xor2(&x7, (const int128 *)(bskey + 128*(i-1) + 112));\
   shufb(&x7, M);\
 
 
@@ -557,14 +557,14 @@ void store64_littleendian(unsigned char *x,uint64 u);
 #define lastround(b0, b1, b2, b3, b4, b5, b6, b7, t0, t1, t2, t3, t4, t5, t6, t7, bskey) \
         shiftrows(b0, b1, b2, b3, b4, b5, b6, b7, 10, SRM0, bskey);\
         sbox(b0, b1, b2, b3, b4, b5, b6, b7, t0, t1, t2, t3, t4, t5, t6, t7);\
-        xor2(&b0,(int128 *)(bskey + 128*10));\
-        xor2(&b1,(int128 *)(bskey + 128*10+16));\
-        xor2(&b4,(int128 *)(bskey + 128*10+32));\
-        xor2(&b6,(int128 *)(bskey + 128*10+48));\
-        xor2(&b3,(int128 *)(bskey + 128*10+64));\
-        xor2(&b7,(int128 *)(bskey + 128*10+80));\
-        xor2(&b2,(int128 *)(bskey + 128*10+96));\
-        xor2(&b5,(int128 *)(bskey + 128*10+112));\
+        xor2(&b0,(const int128 *)(bskey + 128*10));\
+        xor2(&b1,(const int128 *)(bskey + 128*10+16));\
+        xor2(&b4,(const int128 *)(bskey + 128*10+32));\
+        xor2(&b6,(const int128 *)(bskey + 128*10+48));\
+        xor2(&b3,(const int128 *)(bskey + 128*10+64));\
+        xor2(&b7,(const int128 *)(bskey + 128*10+80));\
+        xor2(&b2,(const int128 *)(bskey + 128*10+96));\
+        xor2(&b5,(const int128 *)(bskey + 128*10+112));\
 
 
 #define sbox(b0, b1, b2, b3, b4, b5, b6, b7, t0, t1, t2, t3, s0, s1, s2, s3) \

--- a/src/libsodium/crypto_stream/aes128ctr/portable/int128_aes128ctr.c
+++ b/src/libsodium/crypto_stream/aes128ctr/portable/int128_aes128ctr.c
@@ -53,7 +53,7 @@ void shufd(int128 *r, const int128 *x, const unsigned int c)
 {
   int128 t;
   uint32 *tp = (uint32 *)&t;
-  uint32 *xp = (uint32 *)x;
+  const uint32 *xp = (const uint32 *)x;
   tp[0] = xp[c&3];
   tp[1] = xp[(c>>2)&3];
   tp[2] = xp[(c>>4)&3];

--- a/src/libsodium/crypto_stream/aes128ctr/portable/xor_afternm_aes128ctr.c
+++ b/src/libsodium/crypto_stream/aes128ctr/portable/xor_afternm_aes128ctr.c
@@ -38,7 +38,7 @@ int crypto_stream_xor_afternm(unsigned char *outp, const unsigned char *inp, uns
   uint32 tmp;
 
   /* Copy nonce on the stack */
-  copy2(&nonce_stack, (int128 *) (noncep + 0));
+  copy2(&nonce_stack, (const int128 *) (noncep + 0));
   unsigned char *np = (unsigned char *)&nonce_stack;
 
     enc_block:
@@ -92,14 +92,14 @@ int crypto_stream_xor_afternm(unsigned char *outp, const unsigned char *inp, uns
     tmp += 8;
     store32_bigendian(np + 12, tmp);
 
-    xor2(&xmm8, (int128 *)(inp + 0));
-    xor2(&xmm9, (int128 *)(inp + 16));
-    xor2(&xmm12, (int128 *)(inp + 32));
-    xor2(&xmm14, (int128 *)(inp + 48));
-    xor2(&xmm11, (int128 *)(inp + 64));
-    xor2(&xmm15, (int128 *)(inp + 80));
-    xor2(&xmm10, (int128 *)(inp + 96));
-    xor2(&xmm13, (int128 *)(inp + 112));
+    xor2(&xmm8, (const int128 *)(inp + 0));
+    xor2(&xmm9, (const int128 *)(inp + 16));
+    xor2(&xmm12, (const int128 *)(inp + 32));
+    xor2(&xmm14, (const int128 *)(inp + 48));
+    xor2(&xmm11, (const int128 *)(inp + 64));
+    xor2(&xmm15, (const int128 *)(inp + 80));
+    xor2(&xmm10, (const int128 *)(inp + 96));
+    xor2(&xmm13, (const int128 *)(inp + 112));
 
     *(int128 *) (outp + 0) = xmm8;
     *(int128 *) (outp + 16) = xmm9;
@@ -140,7 +140,7 @@ int crypto_stream_xor_afternm(unsigned char *outp, const unsigned char *inp, uns
     if(lensav == 0) goto end;
 
     b = blp[0]; /* clang false positive */
-    b ^= *(unsigned char *)(inp + 0);
+    b ^= *(const unsigned char *)(inp + 0);
     *(unsigned char *)(outp + 0) = b;
 
     blp += 1;
@@ -156,14 +156,14 @@ int crypto_stream_xor_afternm(unsigned char *outp, const unsigned char *inp, uns
     tmp += 8;
     store32_bigendian(np + 12, tmp);
 
-    xor2(&xmm8, (int128 *)(inp + 0));
-    xor2(&xmm9, (int128 *)(inp + 16));
-    xor2(&xmm12, (int128 *)(inp + 32));
-    xor2(&xmm14, (int128 *)(inp + 48));
-    xor2(&xmm11, (int128 *)(inp + 64));
-    xor2(&xmm15, (int128 *)(inp + 80));
-    xor2(&xmm10, (int128 *)(inp + 96));
-    xor2(&xmm13, (int128 *)(inp + 112));
+    xor2(&xmm8, (const int128 *)(inp + 0));
+    xor2(&xmm9, (const int128 *)(inp + 16));
+    xor2(&xmm12, (const int128 *)(inp + 32));
+    xor2(&xmm14, (const int128 *)(inp + 48));
+    xor2(&xmm11, (const int128 *)(inp + 64));
+    xor2(&xmm15, (const int128 *)(inp + 80));
+    xor2(&xmm10, (const int128 *)(inp + 96));
+    xor2(&xmm13, (const int128 *)(inp + 112));
 
     *(int128 *) (outp + 0) = xmm8;
     *(int128 *) (outp + 16) = xmm9;

--- a/src/libsodium/crypto_stream/aes256estream/hongjun/aes256-ctr.c
+++ b/src/libsodium/crypto_stream/aes256estream/hongjun/aes256-ctr.c
@@ -108,10 +108,10 @@ ECRYPT_process_bytes(int action, ECRYPT_ctx* ctx, const u8* input, u8* output,
     for ( ; msglen >= 16; msglen -= 16, input += 16, output += 16) {
         aes256_enc_block(ctx->counter, keystream, ctx);
 
-        ((u32*)output)[0] = ((u32*)input)[0] ^ ((u32*)keystream)[0] ^ ctx->round_key[Nr][0];
-        ((u32*)output)[1] = ((u32*)input)[1] ^ ((u32*)keystream)[1] ^ ctx->round_key[Nr][1];
-        ((u32*)output)[2] = ((u32*)input)[2] ^ ((u32*)keystream)[2] ^ ctx->round_key[Nr][2];
-        ((u32*)output)[3] = ((u32*)input)[3] ^ ((u32*)keystream)[3] ^ ctx->round_key[Nr][3];
+        ((u32*)output)[0] = ((const u32*)input)[0] ^ ((u32*)keystream)[0] ^ ctx->round_key[Nr][0];
+        ((u32*)output)[1] = ((const u32*)input)[1] ^ ((u32*)keystream)[1] ^ ctx->round_key[Nr][1];
+        ((u32*)output)[2] = ((const u32*)input)[2] ^ ((u32*)keystream)[2] ^ ctx->round_key[Nr][2];
+        ((u32*)output)[3] = ((const u32*)input)[3] ^ ((u32*)keystream)[3] ^ ctx->round_key[Nr][3];
 
         ctx->counter[0]++;
 
@@ -149,7 +149,7 @@ crypto_stream_beforenm(unsigned char *c, const unsigned char *k)
 
 int
 crypto_stream_afternm(unsigned char *outp, unsigned long long len,
-                      const unsigned char *noncep, const unsigned char *c)
+                      const unsigned char *noncep, unsigned char *c)
 {
     ECRYPT_ctx * const ctx = (ECRYPT_ctx *) c;
     unsigned long long i;
@@ -166,7 +166,7 @@ crypto_stream_afternm(unsigned char *outp, unsigned long long len,
 int
 crypto_stream_xor_afternm(unsigned char *outp, const unsigned char *inp,
                           unsigned long long len, const unsigned char *noncep,
-                          const unsigned char *c)
+                          unsigned char *c)
 {
     ECRYPT_ctx * const ctx = (ECRYPT_ctx *) c;
 

--- a/src/libsodium/crypto_stream/aes256estream/hongjun/aes256.h
+++ b/src/libsodium/crypto_stream/aes256estream/hongjun/aes256.h
@@ -166,7 +166,7 @@
 }
 
 /*compute the intermediate values for the first two rounds*/
-void partial_precompute_tworounds(ECRYPT_ctx* ctx)
+static void partial_precompute_tworounds(ECRYPT_ctx* ctx)
 {
   u32 x0,x1,x2,x3,y0,y1,y2,y3;
 

--- a/src/libsodium/include/sodium/crypto_onetimeauth_poly1305.h
+++ b/src/libsodium/include/sodium/crypto_onetimeauth_poly1305.h
@@ -43,6 +43,9 @@ SODIUM_EXPORT
 int crypto_onetimeauth_poly1305_set_implementation(crypto_onetimeauth_poly1305_implementation *impl);
 
 SODIUM_EXPORT
+const char * crypto_onetimeauth_poly1305_implementation_name(void);
+
+SODIUM_EXPORT
 crypto_onetimeauth_poly1305_implementation *
         crypto_onetimeauth_pick_best_implementation(void);
 

--- a/src/libsodium/include/sodium/crypto_stream_aes256estream.h
+++ b/src/libsodium/include/sodium/crypto_stream_aes256estream.h
@@ -43,10 +43,10 @@ SODIUM_EXPORT
 int crypto_stream_aes256estream_beforenm(unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_aes256estream_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_aes256estream_afternm(unsigned char *,unsigned long long,const unsigned char *, unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_aes256estream_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_aes256estream_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *, unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/sodium/compat.c
+++ b/src/libsodium/sodium/compat.c
@@ -16,6 +16,7 @@
 extern "C" {
 #endif
 
+/*
 #undef crypto_hash_sha256_ref
 SODIUM_EXPORT int
 crypto_hash_sha256_ref(unsigned char *out, const unsigned char *in,
@@ -231,6 +232,7 @@ crypto_verify_32_ref(const unsigned char *x, const unsigned char *y)
 {
     return crypto_verify_32(x, y);
 }
+*/
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This commit does the follwing:
- fixes a bunch of "const" declaration missing
- set static a declaration inside a .h file (partial_precompute_tworounds) to prevent missing declaration warnings
- add the declaration of crypto_onetimeauth_poly1305_implementation_name which was missing (remove the declaration and set static if it should not be exposed)
- modifies the definition of crypto_stream_aes256estream_afternm and crypto_stream_aes256estream_xor_afternm to fix a couple of "unconstified" casts which i couldn't fix otherwise
- comments the stuff in compat.c which seems to be unused and, for that reason, is missing functiond declarations.
