### PR TITLE
"long long" causes compiler warnings in C++98 with -pedantic -Werror

### DIFF
--- a/src/libsodium/crypto_auth/crypto_auth.c
+++ b/src/libsodium/crypto_auth/crypto_auth.c
@@ -21,14 +21,14 @@ crypto_auth_primitive(void)
 
 int
 crypto_auth(unsigned char *out, const unsigned char *in,
-            unsigned long long inlen, const unsigned char *k)
+            uint64_t inlen, const unsigned char *k)
 {
     return crypto_auth_hmacsha512256(out, in, inlen, k);
 }
 
 int
 crypto_auth_verify(const unsigned char *h, const unsigned char *in,
-                   unsigned long long inlen,const unsigned char *k)
+                   uint64_t inlen,const unsigned char *k)
 {
     return crypto_auth_hmacsha512256_verify(h, in, inlen, k);
 }

--- a/src/libsodium/crypto_auth/hmacsha256/ref/hmac_hmacsha256.c
+++ b/src/libsodium/crypto_auth/hmacsha256/ref/hmac_hmacsha256.c
@@ -22,12 +22,12 @@ static const unsigned char iv[32] = {
   0x5b,0xe0,0xcd,0x19,
 } ;
 
-int crypto_auth(unsigned char *out,const unsigned char *in,unsigned long long inlen,const unsigned char *k)
+int crypto_auth(unsigned char *out,const unsigned char *in,uint64_t inlen,const unsigned char *k)
 {
   unsigned char h[32];
   unsigned char padded[128];
-  unsigned long long i;
-  unsigned long long bits = 512 + (inlen << 3);
+  uint64_t i;
+  uint64_t bits = 512 + (inlen << 3);
 
   for (i = 0;i < 32;++i) h[i] = iv[i];
 

--- a/src/libsodium/crypto_auth/hmacsha256/ref/verify_hmacsha256.c
+++ b/src/libsodium/crypto_auth/hmacsha256/ref/verify_hmacsha256.c
@@ -1,7 +1,7 @@
 #include "api.h"
 #include "crypto_verify_32.h"
 
-int crypto_auth_verify(const unsigned char *h,const unsigned char *in,unsigned long long inlen,const unsigned char *k)
+int crypto_auth_verify(const unsigned char *h,const unsigned char *in,uint64_t inlen,const unsigned char *k)
 {
   unsigned char correct[32];
   crypto_auth(correct,in,inlen,k);

--- a/src/libsodium/crypto_auth/hmacsha512256/ref/hmac_hmacsha512256.c
+++ b/src/libsodium/crypto_auth/hmacsha512256/ref/hmac_hmacsha512256.c
@@ -9,7 +9,7 @@
 
 #define blocks crypto_hashblocks_sha512
 
-typedef unsigned long long uint64;
+typedef uint64_t uint64;
 
 static const unsigned char iv[64] = {
   0x6a,0x09,0xe6,0x67,0xf3,0xbc,0xc9,0x08,
@@ -22,12 +22,12 @@ static const unsigned char iv[64] = {
   0x5b,0xe0,0xcd,0x19,0x13,0x7e,0x21,0x79
 } ;
 
-int crypto_auth(unsigned char *out,const unsigned char *in,unsigned long long inlen,const unsigned char *k)
+int crypto_auth(unsigned char *out,const unsigned char *in,uint64_t inlen,const unsigned char *k)
 {
   unsigned char h[64];
   unsigned char padded[256];
-  unsigned long long i;
-  unsigned long long bytes = 128 + inlen;
+  uint64_t i;
+  uint64_t bytes = 128 + inlen;
 
   for (i = 0;i < 64;++i) h[i] = iv[i];
 

--- a/src/libsodium/crypto_auth/hmacsha512256/ref/verify_hmacsha512256.c
+++ b/src/libsodium/crypto_auth/hmacsha512256/ref/verify_hmacsha512256.c
@@ -1,7 +1,7 @@
 #include "api.h"
 #include "crypto_verify_32.h"
 
-int crypto_auth_verify(const unsigned char *h,const unsigned char *in,unsigned long long inlen,const unsigned char *k)
+int crypto_auth_verify(const unsigned char *h,const unsigned char *in,uint64_t inlen,const unsigned char *k)
 {
   unsigned char correct[32];
   crypto_auth(correct,in,inlen,k);

--- a/src/libsodium/crypto_auth/try.c
+++ b/src/libsodium/crypto_auth/try.c
@@ -10,7 +10,7 @@
 #include "utils.h"
 #include "windows/windows-quirks.h"
 
-extern unsigned char *alignedcalloc(unsigned long long);
+extern unsigned char *alignedcalloc(uint64_t);
 
 const char *primitiveimplementation = crypto_auth_IMPLEMENTATION;
 
@@ -53,13 +53,13 @@ char checksum[crypto_auth_BYTES * 2 + 1];
 
 const char *checksum_compute(void)
 {
-  long long i;
-  long long j;
+  int64_t i;
+  int64_t j;
 
   for (i = 0;i < CHECKSUM_BYTES;++i) {
-    long long mlen = i;
-    long long klen = crypto_auth_KEYBYTES;
-    long long hlen = crypto_auth_BYTES;
+    int64_t mlen = i;
+    int64_t klen = crypto_auth_KEYBYTES;
+    int64_t hlen = crypto_auth_BYTES;
 
     for (j = -16;j < 0;++j) h[j] = rand();
     for (j = -16;j < 0;++j) k[j] = rand();

--- a/src/libsodium/crypto_box/crypto_box.c
+++ b/src/libsodium/crypto_box/crypto_box.c
@@ -64,7 +64,7 @@ crypto_box_beforenm(unsigned char *k, const unsigned char *pk,
 
 int
 crypto_box_afternm(unsigned char *c, const unsigned char *m,
-                   unsigned long long mlen, const unsigned char *n,
+                   uint64_t mlen, const unsigned char *n,
                    const unsigned char *k)
 {
     return crypto_box_curve25519xsalsa20poly1305_afternm(c, m, mlen, n, k);
@@ -72,7 +72,7 @@ crypto_box_afternm(unsigned char *c, const unsigned char *m,
 
 int
 crypto_box_open_afternm(unsigned char *m, const unsigned char *c,
-                        unsigned long long clen, const unsigned char *n,
+                        uint64_t clen, const unsigned char *n,
                         const unsigned char *k)
 {
     return crypto_box_curve25519xsalsa20poly1305_open_afternm(m, c, clen, n, k);
@@ -80,7 +80,7 @@ crypto_box_open_afternm(unsigned char *m, const unsigned char *c,
 
 int
 crypto_box(unsigned char *c, const unsigned char *m,
-           unsigned long long mlen, const unsigned char *n,
+           uint64_t mlen, const unsigned char *n,
            const unsigned char *pk, const unsigned char *sk)
 {
     return crypto_box_curve25519xsalsa20poly1305(c, m, mlen, n, pk, sk);
@@ -88,7 +88,7 @@ crypto_box(unsigned char *c, const unsigned char *m,
 
 int
 crypto_box_open(unsigned char *m, const unsigned char *c,
-                unsigned long long clen, const unsigned char *n,
+                uint64_t clen, const unsigned char *n,
                 const unsigned char *pk, const unsigned char *sk)
 {
     return crypto_box_curve25519xsalsa20poly1305_open(m, c, clen, n, pk, sk);

--- a/src/libsodium/crypto_box/curve25519xsalsa20poly1305/ref/after_curve25519xsalsa20poly1305.c
+++ b/src/libsodium/crypto_box/curve25519xsalsa20poly1305/ref/after_curve25519xsalsa20poly1305.c
@@ -3,7 +3,7 @@
 
 int crypto_box_afternm(
   unsigned char *c,
-  const unsigned char *m,unsigned long long mlen,
+  const unsigned char *m,uint64_t mlen,
   const unsigned char *n,
   const unsigned char *k
 )
@@ -13,7 +13,7 @@ int crypto_box_afternm(
 
 int crypto_box_open_afternm(
   unsigned char *m,
-  const unsigned char *c,unsigned long long clen,
+  const unsigned char *c,uint64_t clen,
   const unsigned char *n,
   const unsigned char *k
 )

--- a/src/libsodium/crypto_box/curve25519xsalsa20poly1305/ref/box_curve25519xsalsa20poly1305.c
+++ b/src/libsodium/crypto_box/curve25519xsalsa20poly1305/ref/box_curve25519xsalsa20poly1305.c
@@ -2,7 +2,7 @@
 
 int crypto_box(
   unsigned char *c,
-  const unsigned char *m,unsigned long long mlen,
+  const unsigned char *m,uint64_t mlen,
   const unsigned char *n,
   const unsigned char *pk,
   const unsigned char *sk
@@ -15,7 +15,7 @@ int crypto_box(
 
 int crypto_box_open(
   unsigned char *m,
-  const unsigned char *c,unsigned long long clen,
+  const unsigned char *c,uint64_t clen,
   const unsigned char *n,
   const unsigned char *pk,
   const unsigned char *sk

--- a/src/libsodium/crypto_box/try.c
+++ b/src/libsodium/crypto_box/try.c
@@ -9,7 +9,7 @@
 #include "utils.h"
 #include "windows/windows-quirks.h"
 
-extern unsigned char *alignedcalloc(unsigned long long);
+extern unsigned char *alignedcalloc(uint64_t);
 
 const char *primitiveimplementation = crypto_box_IMPLEMENTATION;
 
@@ -81,8 +81,8 @@ char checksum[nlen * 2 + 1];
 
 const char *checksum_compute(void)
 {
-  long long i;
-  long long j;
+  int64_t i;
+  int64_t j;
 
   if (crypto_box_keypair(pka,ska) != 0) return "crypto_box_keypair returns nonzero";
   if (crypto_box_keypair(pkb,skb) != 0) return "crypto_box_keypair returns nonzero";
@@ -90,9 +90,9 @@ const char *checksum_compute(void)
   for (j = 0;j < crypto_box_ZEROBYTES;++j) m[j] = 0;
 
   for (i = 0;i < CHECKSUM_BYTES;++i) {
-    long long mlen = i + crypto_box_ZEROBYTES;
-    long long tlen = i + crypto_box_ZEROBYTES;
-    long long clen = i + crypto_box_ZEROBYTES;
+    int64_t mlen = i + crypto_box_ZEROBYTES;
+    int64_t tlen = i + crypto_box_ZEROBYTES;
+    int64_t clen = i + crypto_box_ZEROBYTES;
 
     for (j = -16;j < 0;++j) ska[j] = rand();
     for (j = -16;j < 0;++j) skb[j] = rand();

--- a/src/libsodium/crypto_generichash/blake2/ref/generichash_blake2b.c
+++ b/src/libsodium/crypto_generichash/blake2/ref/generichash_blake2b.c
@@ -8,7 +8,7 @@
 
 int
 crypto_generichash_blake2b(unsigned char *out, size_t outlen,
-                           const unsigned char *in, unsigned long long inlen,
+                           const unsigned char *in, uint64_t inlen,
                            const unsigned char *key, size_t keylen)
 {
     if (outlen <= 0U || outlen > BLAKE2B_OUTBYTES ||
@@ -24,7 +24,7 @@ crypto_generichash_blake2b(unsigned char *out, size_t outlen,
 
 int
 crypto_generichash_blake2b_salt_personal(unsigned char *out, size_t outlen,
-                                         const unsigned char *in, unsigned long long inlen,
+                                         const unsigned char *in, uint64_t inlen,
                                          const unsigned char *key, size_t keylen,
                                          const unsigned char *salt,
                                          const unsigned char *personal)
@@ -91,7 +91,7 @@ crypto_generichash_blake2b_init_salt_personal(crypto_generichash_blake2b_state *
 int
 crypto_generichash_blake2b_update(crypto_generichash_blake2b_state *state,
                                   const unsigned char *in,
-                                  unsigned long long inlen)
+                                  uint64_t inlen)
 {
     return blake2b_update(state, (const uint8_t *) in, (uint64_t) inlen);
 }

--- a/src/libsodium/crypto_generichash/crypto_generichash.c
+++ b/src/libsodium/crypto_generichash/crypto_generichash.c
@@ -50,7 +50,7 @@ const char *crypto_generichash_primitive(void)
 
 int
 crypto_generichash(unsigned char *out, size_t outlen, const unsigned char *in,
-                   unsigned long long inlen, const unsigned char *key,
+                   uint64_t inlen, const unsigned char *key,
                    size_t keylen)
 {
     return crypto_generichash_blake2b(out, outlen, in, inlen, key, keylen);
@@ -69,7 +69,7 @@ crypto_generichash_init(crypto_generichash_state *state,
 int
 crypto_generichash_update(crypto_generichash_state *state,
                           const unsigned char *in,
-                          unsigned long long inlen)
+                          uint64_t inlen)
 {
     return crypto_generichash_blake2b_update
         ((crypto_generichash_blake2b_state *) state, in, inlen);

--- a/src/libsodium/crypto_hash/crypto_hash.c
+++ b/src/libsodium/crypto_hash/crypto_hash.c
@@ -3,7 +3,7 @@
 
 int
 crypto_hash(unsigned char *out, const unsigned char *in,
-            unsigned long long inlen)
+            uint64_t inlen)
 {
     return crypto_hash_sha512(out, in, inlen);
 }

--- a/src/libsodium/crypto_hash/sha256/ref/hash_sha256.c
+++ b/src/libsodium/crypto_hash/sha256/ref/hash_sha256.c
@@ -22,12 +22,12 @@ static const unsigned char iv[32] = {
   0x5b,0xe0,0xcd,0x19,
 } ;
 
-int crypto_hash(unsigned char *out,const unsigned char *in,unsigned long long inlen)
+int crypto_hash(unsigned char *out,const unsigned char *in,uint64_t inlen)
 {
   unsigned char h[32];
   unsigned char padded[128];
-  unsigned long long i;
-  unsigned long long bits = inlen << 3;
+  uint64_t i;
+  uint64_t bits = inlen << 3;
 
   for (i = 0;i < 32;++i) h[i] = iv[i];
 

--- a/src/libsodium/crypto_hash/sha512/ref/hash_sha512.c
+++ b/src/libsodium/crypto_hash/sha512/ref/hash_sha512.c
@@ -20,14 +20,14 @@ static const unsigned char iv[64] = {
   0x5b,0xe0,0xcd,0x19,0x13,0x7e,0x21,0x79
 } ;
 
-typedef unsigned long long uint64;
+typedef uint64_t uint64;
 
-int crypto_hash(unsigned char *out,const unsigned char *in,unsigned long long inlen)
+int crypto_hash(unsigned char *out,const unsigned char *in,uint64_t inlen)
 {
   unsigned char h[64];
   unsigned char padded[256];
-  unsigned long long i;
-  unsigned long long bytes = inlen;
+  uint64_t i;
+  uint64_t bytes = inlen;
 
   for (i = 0;i < 64;++i) h[i] = iv[i];
 

--- a/src/libsodium/crypto_hash/try.c
+++ b/src/libsodium/crypto_hash/try.c
@@ -9,7 +9,7 @@
 #include "utils.h"
 #include "windows/windows-quirks.h"
 
-extern unsigned char *alignedcalloc(unsigned long long);
+extern unsigned char *alignedcalloc(uint64_t);
 
 const char *primitiveimplementation = crypto_hash_IMPLEMENTATION;
 
@@ -47,12 +47,12 @@ char checksum[crypto_hash_BYTES * 2 + 1];
 
 const char *checksum_compute(void)
 {
-  long long i;
-  long long j;
+  int64_t i;
+  int64_t j;
 
   for (i = 0;i < CHECKSUM_BYTES;++i) {
-    long long hlen = crypto_hash_BYTES;
-    long long mlen = i;
+    int64_t hlen = crypto_hash_BYTES;
+    int64_t mlen = i;
     for (j = -16;j < 0;++j) h[j] = rand();
     for (j = hlen;j < hlen + 16;++j) h[j] = rand();
     for (j = -16;j < hlen + 16;++j) h2[j] = h[j];

--- a/src/libsodium/crypto_hashblocks/sha256/ref/blocks_sha256.c
+++ b/src/libsodium/crypto_hashblocks/sha256/ref/blocks_sha256.c
@@ -62,7 +62,7 @@ static void store_bigendian(unsigned char *x,uint32 u)
   b = a; \
   a = T1 + T2;
 
-int crypto_hashblocks(unsigned char *statebytes,const unsigned char *in,unsigned long long inlen)
+int crypto_hashblocks(unsigned char *statebytes,const unsigned char *in,uint64_t inlen)
 {
   uint32 state[8];
   uint32 a;

--- a/src/libsodium/crypto_hashblocks/sha512/ref/blocks_sha512.c
+++ b/src/libsodium/crypto_hashblocks/sha512/ref/blocks_sha512.c
@@ -1,6 +1,6 @@
 #include "api.h"
 
-typedef unsigned long long uint64;
+typedef uint64_t uint64;
 
 static uint64 load_bigendian(const unsigned char *x)
 {
@@ -70,7 +70,7 @@ static void store_bigendian(unsigned char *x,uint64 u)
   b = a; \
   a = T1 + T2;
 
-int crypto_hashblocks(unsigned char *statebytes,const unsigned char *in,unsigned long long inlen)
+int crypto_hashblocks(unsigned char *statebytes,const unsigned char *in,uint64_t inlen)
 {
   uint64 state[8];
   uint64 a;

--- a/src/libsodium/crypto_hashblocks/try.c
+++ b/src/libsodium/crypto_hashblocks/try.c
@@ -9,7 +9,7 @@
 #include "utils.h"
 #include "windows/windows-quirks.h"
 
-extern unsigned char *alignedcalloc(unsigned long long);
+extern unsigned char *alignedcalloc(uint64_t);
 
 const char *primitiveimplementation = crypto_hashblocks_IMPLEMENTATION;
 
@@ -47,12 +47,12 @@ char checksum[crypto_hashblocks_STATEBYTES * 2 + 1];
 
 const char *checksum_compute(void)
 {
-  long long i;
-  long long j;
+  int64_t i;
+  int64_t j;
 
   for (i = 0;i < CHECKSUM_BYTES;++i) {
-    long long hlen = crypto_hashblocks_STATEBYTES;
-    long long mlen = i;
+    int64_t hlen = crypto_hashblocks_STATEBYTES;
+    int64_t mlen = i;
     for (j = -16;j < 0;++j) h[j] = rand();
     for (j = hlen;j < hlen + 16;++j) h[j] = rand();
     for (j = -16;j < hlen + 16;++j) h2[j] = h[j];

--- a/src/libsodium/crypto_onetimeauth/crypto_onetimeauth.c
+++ b/src/libsodium/crypto_onetimeauth/crypto_onetimeauth.c
@@ -21,14 +21,14 @@ crypto_onetimeauth_primitive(void)
 
 int
 crypto_onetimeauth(unsigned char *out, const unsigned char *in,
-                   unsigned long long inlen, const unsigned char *k)
+                   uint64_t inlen, const unsigned char *k)
 {
     return crypto_onetimeauth_poly1305(out, in, inlen, k);
 }
 
 int
 crypto_onetimeauth_verify(const unsigned char *h, const unsigned char *in,
-                          unsigned long long inlen, const unsigned char *k)
+                          uint64_t inlen, const unsigned char *k)
 {
     return crypto_onetimeauth_poly1305_verify(h, in, inlen, k);
 }

--- a/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c
+++ b/src/libsodium/crypto_onetimeauth/poly1305/53/auth_poly1305_53.c
@@ -48,7 +48,7 @@ static const double poly1305_53_constants[] = {
 , 535219245894202480694386063513315216128475136.0 /* offset3 = alpha96 + 2^130 - 2^97 */
 } ;
 
-int crypto_onetimeauth(unsigned char *out,const unsigned char *m,unsigned long long l,const unsigned char *k)
+int crypto_onetimeauth(unsigned char *out,const unsigned char *m,uint64_t l,const unsigned char *k)
 {
   register const unsigned char *r = k;
   register const unsigned char *s = k + 16;

--- a/src/libsodium/crypto_onetimeauth/poly1305/53/verify_poly1305_53.c
+++ b/src/libsodium/crypto_onetimeauth/poly1305/53/verify_poly1305_53.c
@@ -2,7 +2,7 @@
 #include "crypto_onetimeauth_poly1305_53.h"
 #include "crypto_verify_16.h"
 
-int crypto_onetimeauth_verify(const unsigned char *h,const unsigned char *in,unsigned long long inlen,const unsigned char *k)
+int crypto_onetimeauth_verify(const unsigned char *h,const unsigned char *in,uint64_t inlen,const unsigned char *k)
 {
   unsigned char correct[16];
   crypto_onetimeauth(correct,in,inlen,k);

--- a/src/libsodium/crypto_onetimeauth/poly1305/donna/auth_poly1305_donna.c
+++ b/src/libsodium/crypto_onetimeauth/poly1305/donna/auth_poly1305_donna.c
@@ -7,14 +7,14 @@
 
 int
 crypto_onetimeauth(unsigned char *out, const unsigned char *m,
-                   unsigned long long inlen, const unsigned char *key)
+                   uint64_t inlen, const unsigned char *key)
 {
 	uint32_t t0,t1,t2,t3;
 	uint32_t h0,h1,h2,h3,h4;
 	uint32_t r0,r1,r2,r3,r4;
 	uint32_t s1,s2,s3,s4;
 	uint32_t b, nb;
-	unsigned long long j;
+	uint64_t j;
 	uint64_t t[5];
 	uint64_t f0,f1,f2,f3;
 	uint32_t g0,g1,g2,g3,g4;

--- a/src/libsodium/crypto_onetimeauth/poly1305/donna/verify_poly1305_donna.c
+++ b/src/libsodium/crypto_onetimeauth/poly1305/donna/verify_poly1305_donna.c
@@ -2,7 +2,7 @@
 #include "crypto_onetimeauth_poly1305_donna.h"
 #include "crypto_verify_16.h"
 
-int crypto_onetimeauth_verify(const unsigned char *h,const unsigned char *in,unsigned long long inlen,const unsigned char *k)
+int crypto_onetimeauth_verify(const unsigned char *h,const unsigned char *in,uint64_t inlen,const unsigned char *k)
 {
   unsigned char correct[16];
   crypto_onetimeauth(correct,in,inlen,k);

--- a/src/libsodium/crypto_onetimeauth/poly1305/onetimeauth_poly1305.c
+++ b/src/libsodium/crypto_onetimeauth/poly1305/onetimeauth_poly1305.c
@@ -21,7 +21,7 @@ crypto_onetimeauth_poly1305_implementation_name(void)
 
 int
 crypto_onetimeauth_poly1305(unsigned char *out, const unsigned char *in,
-                            unsigned long long inlen, const unsigned char *k)
+                            uint64_t inlen, const unsigned char *k)
 {
     return implementation->onetimeauth(out, in, inlen, k);
 }
@@ -29,7 +29,7 @@ crypto_onetimeauth_poly1305(unsigned char *out, const unsigned char *in,
 int
 crypto_onetimeauth_poly1305_verify(const unsigned char *h,
                                    const unsigned char *in,
-                                   unsigned long long inlen,
+                                   uint64_t inlen,
                                    const unsigned char *k)
 {
     return implementation->onetimeauth_verify(h, in, inlen, k);

--- a/src/libsodium/crypto_onetimeauth/poly1305/onetimeauth_poly1305_try.c
+++ b/src/libsodium/crypto_onetimeauth/poly1305/onetimeauth_poly1305_try.c
@@ -55,13 +55,13 @@ deallocate(void)
 static const char *
 checksum_compute(void)
 {
-    long long i;
-    long long j;
+    int64_t i;
+    int64_t j;
 
     for (i = 0;i < CHECKSUM_BYTES;++i) {
-        long long mlen = i;
-        long long klen = crypto_onetimeauth_KEYBYTES;
-        long long hlen = crypto_onetimeauth_BYTES;
+        int64_t mlen = i;
+        int64_t klen = crypto_onetimeauth_KEYBYTES;
+        int64_t hlen = crypto_onetimeauth_BYTES;
 
         for (j = -16;j < 0;++j) h[j] = rand();
         for (j = -16;j < 0;++j) k[j] = rand();

--- a/src/libsodium/crypto_scalarmult/try.c
+++ b/src/libsodium/crypto_scalarmult/try.c
@@ -9,7 +9,7 @@
 #include "utils.h"
 #include "windows/windows-quirks.h"
 
-extern unsigned char *alignedcalloc(unsigned long long);
+extern unsigned char *alignedcalloc(uint64_t);
 
 const char *primitiveimplementation = crypto_scalarmult_IMPLEMENTATION;
 
@@ -63,9 +63,9 @@ char checksum[crypto_scalarmult_BYTES * 2 + 1];
 
 const char *checksum_compute(void)
 {
-  long long i;
-  long long j;
-  long long tests;
+  int64_t i;
+  int64_t j;
+  int64_t tests;
 
   for (i = 0;i < mlen;++i) m[i] = i;
   for (i = 0;i < nlen;++i) n[i] = i + 1;

--- a/src/libsodium/crypto_secretbox/crypto_secretbox.c
+++ b/src/libsodium/crypto_secretbox/crypto_secretbox.c
@@ -39,7 +39,7 @@ crypto_secretbox_primitive(void)
 
 int
 crypto_secretbox(unsigned char *c, const unsigned char *m,
-                 unsigned long long mlen, const unsigned char *n,
+                 uint64_t mlen, const unsigned char *n,
                  const unsigned char *k)
 {
     return crypto_secretbox_xsalsa20poly1305(c, m, mlen, n, k);
@@ -47,7 +47,7 @@ crypto_secretbox(unsigned char *c, const unsigned char *m,
 
 int
 crypto_secretbox_open(unsigned char *m, const unsigned char *c,
-                      unsigned long long clen, const unsigned char *n,
+                      uint64_t clen, const unsigned char *n,
                       const unsigned char *k)
 {
     return crypto_secretbox_xsalsa20poly1305_open(m, c, clen, n, k);

--- a/src/libsodium/crypto_secretbox/try.c
+++ b/src/libsodium/crypto_secretbox/try.c
@@ -9,7 +9,7 @@
 #include "utils.h"
 #include "windows/windows-quirks.h"
 
-extern unsigned char *alignedcalloc(unsigned long long);
+extern unsigned char *alignedcalloc(uint64_t);
 
 const char *primitiveimplementation = crypto_secretbox_IMPLEMENTATION;
 
@@ -63,15 +63,15 @@ char checksum[klen * 2 + 1];
 
 const char *checksum_compute(void)
 {
-  long long i;
-  long long j;
+  int64_t i;
+  int64_t j;
 
   for (j = 0;j < crypto_secretbox_ZEROBYTES;++j) m[j] = 0;
 
   for (i = 0;i < CHECKSUM_BYTES;++i) {
-    long long mlen = i + crypto_secretbox_ZEROBYTES;
-    long long tlen = i + crypto_secretbox_ZEROBYTES;
-    long long clen = i + crypto_secretbox_ZEROBYTES;
+    int64_t mlen = i + crypto_secretbox_ZEROBYTES;
+    int64_t tlen = i + crypto_secretbox_ZEROBYTES;
+    int64_t clen = i + crypto_secretbox_ZEROBYTES;
 
     for (j = -16;j < 0;++j) k[j] = rand();
     for (j = -16;j < 0;++j) n[j] = rand();

--- a/src/libsodium/crypto_secretbox/xsalsa20poly1305/ref/box_xsalsa20poly1305.c
+++ b/src/libsodium/crypto_secretbox/xsalsa20poly1305/ref/box_xsalsa20poly1305.c
@@ -4,7 +4,7 @@
 
 int crypto_secretbox(
   unsigned char *c,
-  const unsigned char *m,unsigned long long mlen,
+  const unsigned char *m,uint64_t mlen,
   const unsigned char *n,
   const unsigned char *k
 )
@@ -19,7 +19,7 @@ int crypto_secretbox(
 
 int crypto_secretbox_open(
   unsigned char *m,
-  const unsigned char *c,unsigned long long clen,
+  const unsigned char *c,uint64_t clen,
   const unsigned char *n,
   const unsigned char *k
 )

--- a/src/libsodium/crypto_shorthash/crypto_shorthash.c
+++ b/src/libsodium/crypto_shorthash/crypto_shorthash.c
@@ -21,7 +21,7 @@ crypto_shorthash_primitive(void)
 
 int
 crypto_shorthash(unsigned char *out, const unsigned char *in,
-                 unsigned long long inlen, const unsigned char *k)
+                 uint64_t inlen, const unsigned char *k)
 {
     return crypto_shorthash_siphash24(out, in, inlen, k);
 }

--- a/src/libsodium/crypto_shorthash/siphash24/ref/shorthash_siphash24.c
+++ b/src/libsodium/crypto_shorthash/siphash24/ref/shorthash_siphash24.c
@@ -35,7 +35,7 @@ typedef crypto_uint8   u8;
     v2 += v1; v1=ROTL(v1,17); v1 ^= v2; v2=ROTL(v2,32); \
   } while(0)
 
-int crypto_shorthash(unsigned char *out,const unsigned char *in,unsigned long long inlen,const unsigned char *k)
+int crypto_shorthash(unsigned char *out,const unsigned char *in,uint64_t inlen,const unsigned char *k)
 {
   /* "somepseudorandomlygeneratedbytes" */
   u64 v0 = 0x736f6d6570736575ULL;

--- a/src/libsodium/crypto_sign/crypto_sign.c
+++ b/src/libsodium/crypto_sign/crypto_sign.c
@@ -45,16 +45,16 @@ crypto_sign_keypair(unsigned char *pk, unsigned char *sk)
 }
 
 int
-crypto_sign(unsigned char *sm, unsigned long long *smlen,
-            const unsigned char *m, unsigned long long mlen,
+crypto_sign(unsigned char *sm, uint64_t *smlen,
+            const unsigned char *m, uint64_t mlen,
             const unsigned char *sk)
 {
     return crypto_sign_ed25519(sm, smlen, m, mlen, sk);
 }
 
 int
-crypto_sign_open(unsigned char *m, unsigned long long *mlen,
-                 const unsigned char *sm, unsigned long long smlen,
+crypto_sign_open(unsigned char *m, uint64_t *mlen,
+                 const unsigned char *sm, uint64_t smlen,
                  const unsigned char *pk)
 {
     return crypto_sign_ed25519_open(m, mlen, sm, smlen, pk);

--- a/src/libsodium/crypto_sign/ed25519/ref10/ge_scalarmult_base.c
+++ b/src/libsodium/crypto_sign/ed25519/ref10/ge_scalarmult_base.c
@@ -14,7 +14,7 @@ static unsigned char equal(signed char b,signed char c)
 
 static unsigned char negative(signed char b)
 {
-  unsigned long long x = b; /* 18446744073709551361..18446744073709551615: yes; 0..255: no */
+  uint64_t x = b; /* 18446744073709551361..18446744073709551615: yes; 0..255: no */
   x >>= 63; /* 1: yes; 0: no */
   return x;
 }

--- a/src/libsodium/crypto_sign/ed25519/ref10/open.c
+++ b/src/libsodium/crypto_sign/ed25519/ref10/open.c
@@ -5,8 +5,8 @@
 #include "sc.h"
 
 int crypto_sign_open(
-  unsigned char *m,unsigned long long *mlen,
-  const unsigned char *sm,unsigned long long smlen,
+  unsigned char *m,uint64_t *mlen,
+  const unsigned char *sm,uint64_t smlen,
   const unsigned char *pk
 )
 {
@@ -14,7 +14,7 @@ int crypto_sign_open(
   unsigned char checkr[32];
   ge_p3 A;
   ge_p2 R;
-  unsigned long long i;
+  uint64_t i;
 
   *mlen = -1;
   if (smlen < 64) return -1;

--- a/src/libsodium/crypto_sign/ed25519/ref10/sign.c
+++ b/src/libsodium/crypto_sign/ed25519/ref10/sign.c
@@ -4,8 +4,8 @@
 #include "sc.h"
 
 int crypto_sign(
-  unsigned char *sm,unsigned long long *smlen,
-  const unsigned char *m,unsigned long long mlen,
+  unsigned char *sm,uint64_t *smlen,
+  const unsigned char *m,uint64_t mlen,
   const unsigned char *sk
 )
 {
@@ -13,7 +13,7 @@ int crypto_sign(
   unsigned char r[64];
   unsigned char hram[64];
   ge_p3 R;
-  unsigned long long i;
+  uint64_t i;
 
   crypto_hash_sha512(az,sk,32);
   az[0] &= 248;

--- a/src/libsodium/crypto_sign/edwards25519sha512batch/ref/sign_edwards25519sha512batch.c
+++ b/src/libsodium/crypto_sign/edwards25519sha512batch/ref/sign_edwards25519sha512batch.c
@@ -27,8 +27,8 @@ int crypto_sign_keypair(
 }
 
 int crypto_sign(
-    unsigned char *sm,unsigned long long *smlen,
-    const unsigned char *m,unsigned long long mlen,
+    unsigned char *sm,uint64_t *smlen,
+    const unsigned char *m,uint64_t mlen,
     const unsigned char *sk
     )
 {
@@ -36,7 +36,7 @@ int crypto_sign(
   ge25519 ger;
   unsigned char r[32];
   unsigned char s[32];
-  unsigned long long i;
+  uint64_t i;
   unsigned char hmg[crypto_hash_sha512_BYTES];
   unsigned char hmr[crypto_hash_sha512_BYTES];
 
@@ -69,12 +69,12 @@ int crypto_sign(
 }
 
 int crypto_sign_open(
-    unsigned char *m,unsigned long long *mlen,
-    const unsigned char *sm,unsigned long long smlen,
+    unsigned char *m,uint64_t *mlen,
+    const unsigned char *sm,uint64_t smlen,
     const unsigned char *pk
     )
 {
-  unsigned long long i;
+  uint64_t i;
   unsigned char t1[32], t2[32];
   ge25519 get1, get2, gepk;
   sc25519 schmr, scs;

--- a/src/libsodium/crypto_sign/try.c
+++ b/src/libsodium/crypto_sign/try.c
@@ -12,15 +12,15 @@
 #define MAXTEST_BYTES 10000
 #define TUNE_BYTES 1536
 
-extern unsigned char *alignedcalloc(unsigned long long);
+extern unsigned char *alignedcalloc(uint64_t);
 
 const char *primitiveimplementation = crypto_sign_IMPLEMENTATION;
 
 static unsigned char *pk;
 static unsigned char *sk;
-static unsigned char *m; unsigned long long mlen;
-static unsigned char *sm; unsigned long long smlen;
-static unsigned char *t; unsigned long long tlen;
+static unsigned char *m; uint64_t mlen;
+static unsigned char *sm; uint64_t smlen;
+static unsigned char *t; uint64_t tlen;
 
 void preallocate(void)
 {
@@ -56,9 +56,9 @@ char checksum[crypto_sign_BYTES * 2 + 1];
 
 const char *checksum_compute(void)
 {
-  long long mlen;
-  long long i;
-  long long j;
+  int64_t mlen;
+  int64_t i;
+  int64_t j;
 
   if (crypto_sign_keypair(pk,sk) != 0) return "crypto_sign_keypair returns nonzero";
   for (mlen = 0;mlen < MAXTEST_BYTES;mlen += 1 + (mlen / 16)) {

--- a/src/libsodium/crypto_stream/aes128ctr/portable/afternm_aes128ctr.c
+++ b/src/libsodium/crypto_stream/aes128ctr/portable/afternm_aes128ctr.c
@@ -7,7 +7,7 @@
 #include "common.h"
 #include "consts.h"
 
-int crypto_stream_afternm(unsigned char *outp, unsigned long long len, const unsigned char *noncep, const unsigned char *c)
+int crypto_stream_afternm(unsigned char *outp, uint64_t len, const unsigned char *noncep, const unsigned char *c)
 {
 
   int128 xmm0;
@@ -29,7 +29,7 @@ int crypto_stream_afternm(unsigned char *outp, unsigned long long len, const uns
   int128 xmm15;
 
   int128 nonce_stack;
-  unsigned long long lensav;
+  uint64_t lensav;
   unsigned char bl[128];
   unsigned char *blp;
   unsigned char *np;

--- a/src/libsodium/crypto_stream/aes128ctr/portable/int128.h
+++ b/src/libsodium/crypto_stream/aes128ctr/portable/int128.h
@@ -4,8 +4,8 @@
 #include "common.h"
 
 typedef struct{
-  unsigned long long a;
-  unsigned long long b;
+  uint64_t a;
+  uint64_t b;
 } int128;
 
 #define xor2 crypto_stream_aes128ctr_portable_xor2

--- a/src/libsodium/crypto_stream/aes128ctr/portable/stream_aes128ctr.c
+++ b/src/libsodium/crypto_stream/aes128ctr/portable/stream_aes128ctr.c
@@ -2,7 +2,7 @@
 
 int crypto_stream(
         unsigned char *out,
-        unsigned long long outlen,
+        uint64_t outlen,
         const unsigned char *n,
         const unsigned char *k
         )
@@ -16,7 +16,7 @@ int crypto_stream(
 int crypto_stream_xor(
         unsigned char *out,
         const unsigned char *in,
-        unsigned long long inlen,
+        uint64_t inlen,
         const unsigned char *n,
         const unsigned char *k
         )

--- a/src/libsodium/crypto_stream/aes128ctr/portable/xor_afternm_aes128ctr.c
+++ b/src/libsodium/crypto_stream/aes128ctr/portable/xor_afternm_aes128ctr.c
@@ -8,7 +8,7 @@
 #include "common.h"
 #include "consts.h"
 
-int crypto_stream_xor_afternm(unsigned char *outp, const unsigned char *inp, unsigned long long len, const unsigned char *noncep, const unsigned char *c)
+int crypto_stream_xor_afternm(unsigned char *outp, const unsigned char *inp, uint64_t len, const unsigned char *noncep, const unsigned char *c)
 {
 
   int128 xmm0;
@@ -30,7 +30,7 @@ int crypto_stream_xor_afternm(unsigned char *outp, const unsigned char *inp, uns
   int128 xmm15;
 
   int128 nonce_stack;
-  unsigned long long lensav;
+  uint64_t lensav;
   unsigned char bl[128];
   unsigned char *blp;
   unsigned char *np;

--- a/src/libsodium/crypto_stream/aes256estream/hongjun/aes256-ctr.c
+++ b/src/libsodium/crypto_stream/aes256estream/hongjun/aes256-ctr.c
@@ -186,11 +186,11 @@ crypto_stream_beforenm(unsigned char *c, const unsigned char *k)
 }
 
 int
-crypto_stream_afternm(unsigned char *outp, unsigned long long len,
+crypto_stream_afternm(unsigned char *outp, uint64_t len,
                       const unsigned char *noncep, const unsigned char *c)
 {
     ECRYPT_ctx * const ctx = (ECRYPT_ctx *) c;
-    unsigned long long i;
+    uint64_t i;
 
     ECRYPT_ivsetup(ctx, noncep);
     for (i = 0U; i < len; ++i) {
@@ -203,7 +203,7 @@ crypto_stream_afternm(unsigned char *outp, unsigned long long len,
 
 int
 crypto_stream_xor_afternm(unsigned char *outp, const unsigned char *inp,
-                          unsigned long long len, const unsigned char *noncep,
+                          uint64_t len, const unsigned char *noncep,
                           const unsigned char *c)
 {
     ECRYPT_ctx * const ctx = (ECRYPT_ctx *) c;
@@ -215,7 +215,7 @@ crypto_stream_xor_afternm(unsigned char *outp, const unsigned char *inp,
 }
 
 int
-crypto_stream(unsigned char *out, unsigned long long outlen,
+crypto_stream(unsigned char *out, uint64_t outlen,
               const unsigned char *n, const unsigned char *k)
 {
     unsigned char d[crypto_stream_BEFORENMBYTES];
@@ -227,7 +227,7 @@ crypto_stream(unsigned char *out, unsigned long long outlen,
 }
 
 int crypto_stream_xor(unsigned char *out, const unsigned char *in,
-                      unsigned long long inlen, const unsigned char *n,
+                      uint64_t inlen, const unsigned char *n,
                       const unsigned char *k)
 {
     unsigned char d[crypto_stream_BEFORENMBYTES];

--- a/src/libsodium/crypto_stream/crypto_stream.c
+++ b/src/libsodium/crypto_stream/crypto_stream.c
@@ -20,7 +20,7 @@ crypto_stream_primitive(void)
 }
 
 int
-crypto_stream(unsigned char *c, unsigned long long clen,
+crypto_stream(unsigned char *c, uint64_t clen,
               const unsigned char *n, const unsigned char *k)
 {
     return crypto_stream_xsalsa20(c, clen, n, k);
@@ -29,7 +29,7 @@ crypto_stream(unsigned char *c, unsigned long long clen,
 
 int
 crypto_stream_xor(unsigned char *c, const unsigned char *m,
-                  unsigned long long mlen, const unsigned char *n,
+                  uint64_t mlen, const unsigned char *n,
                   const unsigned char *k)
 {
     return crypto_stream_xsalsa20_xor(c, m, mlen, n, k);

--- a/src/libsodium/crypto_stream/salsa20/ref/stream_salsa20_ref.c
+++ b/src/libsodium/crypto_stream/salsa20/ref/stream_salsa20_ref.c
@@ -16,14 +16,14 @@ static const unsigned char sigma[16] = {
 };
 
 int crypto_stream(
-        unsigned char *c,unsigned long long clen,
+        unsigned char *c,uint64_t clen,
   const unsigned char *n,
   const unsigned char *k
 )
 {
   unsigned char in[16];
   unsigned char block[64];
-  unsigned long long i;
+  uint64_t i;
   unsigned int u;
 
   if (!clen) return 0;

--- a/src/libsodium/crypto_stream/salsa20/ref/xor_salsa20_ref.c
+++ b/src/libsodium/crypto_stream/salsa20/ref/xor_salsa20_ref.c
@@ -17,14 +17,14 @@ static const unsigned char sigma[16] = {
 
 int crypto_stream_xor(
         unsigned char *c,
-  const unsigned char *m,unsigned long long mlen,
+  const unsigned char *m,uint64_t mlen,
   const unsigned char *n,
   const unsigned char *k
 )
 {
   unsigned char in[16];
   unsigned char block[64];
-  unsigned long long i;
+  uint64_t i;
   unsigned int u;
 
   if (!mlen) return 0;

--- a/src/libsodium/crypto_stream/salsa2012/ref/stream_salsa2012.c
+++ b/src/libsodium/crypto_stream/salsa2012/ref/stream_salsa2012.c
@@ -14,14 +14,14 @@ static const unsigned char sigma[16] = {
 };
 
 int crypto_stream(
-        unsigned char *c,unsigned long long clen,
+        unsigned char *c,uint64_t clen,
   const unsigned char *n,
   const unsigned char *k
 )
 {
   unsigned char in[16];
   unsigned char block[64];
-  unsigned long long i;
+  uint64_t i;
   unsigned int u;
 
   if (!clen) return 0;

--- a/src/libsodium/crypto_stream/salsa2012/ref/xor_salsa2012.c
+++ b/src/libsodium/crypto_stream/salsa2012/ref/xor_salsa2012.c
@@ -15,14 +15,14 @@ static const unsigned char sigma[16] = {
 
 int crypto_stream_xor(
         unsigned char *c,
-  const unsigned char *m,unsigned long long mlen,
+  const unsigned char *m,uint64_t mlen,
   const unsigned char *n,
   const unsigned char *k
 )
 {
   unsigned char in[16];
   unsigned char block[64];
-  unsigned long long i;
+  uint64_t i;
   unsigned int u;
 
   if (!mlen) return 0;

--- a/src/libsodium/crypto_stream/salsa208/ref/stream_salsa208.c
+++ b/src/libsodium/crypto_stream/salsa208/ref/stream_salsa208.c
@@ -14,14 +14,14 @@ static const unsigned char sigma[16] = {
 };
 
 int crypto_stream(
-        unsigned char *c,unsigned long long clen,
+        unsigned char *c,uint64_t clen,
   const unsigned char *n,
   const unsigned char *k
 )
 {
   unsigned char in[16];
   unsigned char block[64];
-  unsigned long long i;
+  uint64_t i;
   unsigned int u;
 
   if (!clen) return 0;

--- a/src/libsodium/crypto_stream/salsa208/ref/xor_salsa208.c
+++ b/src/libsodium/crypto_stream/salsa208/ref/xor_salsa208.c
@@ -15,14 +15,14 @@ static const unsigned char sigma[16] = {
 
 int crypto_stream_xor(
         unsigned char *c,
-  const unsigned char *m,unsigned long long mlen,
+  const unsigned char *m,uint64_t mlen,
   const unsigned char *n,
   const unsigned char *k
 )
 {
   unsigned char in[16];
   unsigned char block[64];
-  unsigned long long i;
+  uint64_t i;
   unsigned int u;
 
   if (!mlen) return 0;

--- a/src/libsodium/crypto_stream/try.c
+++ b/src/libsodium/crypto_stream/try.c
@@ -9,7 +9,7 @@
 #include "utils.h"
 #include "windows/windows-quirks.h"
 
-extern unsigned char *alignedcalloc(unsigned long long);
+extern unsigned char *alignedcalloc(uint64_t);
 
 const char *primitiveimplementation = crypto_stream_IMPLEMENTATION;
 
@@ -59,15 +59,15 @@ char checksum[crypto_stream_KEYBYTES * 2 + 1];
 
 const char *checksum_compute(void)
 {
-  long long i;
-  long long j;
+  int64_t i;
+  int64_t j;
 
   for (i = 0;i < CHECKSUM_BYTES;++i) {
-    long long mlen = i;
-    long long clen = i;
-    long long slen = i;
-    long long klen = crypto_stream_KEYBYTES;
-    long long nlen = crypto_stream_NONCEBYTES;
+    int64_t mlen = i;
+    int64_t clen = i;
+    int64_t slen = i;
+    int64_t klen = crypto_stream_KEYBYTES;
+    int64_t nlen = crypto_stream_NONCEBYTES;
     for (j = -16;j < 0;++j) m[j] = rand();
     for (j = -16;j < 0;++j) c[j] = rand();
     for (j = -16;j < 0;++j) s[j] = rand();

--- a/src/libsodium/crypto_stream/xsalsa20/ref/stream_xsalsa20.c
+++ b/src/libsodium/crypto_stream/xsalsa20/ref/stream_xsalsa20.c
@@ -13,7 +13,7 @@ static const unsigned char sigma[16] = {
 };
 
 int crypto_stream(
-        unsigned char *c,unsigned long long clen,
+        unsigned char *c,uint64_t clen,
   const unsigned char *n,
   const unsigned char *k
 )

--- a/src/libsodium/crypto_stream/xsalsa20/ref/xor_xsalsa20.c
+++ b/src/libsodium/crypto_stream/xsalsa20/ref/xor_xsalsa20.c
@@ -14,7 +14,7 @@ static const unsigned char sigma[16] = {
 
 int crypto_stream_xor(
         unsigned char *c,
-  const unsigned char *m,unsigned long long mlen,
+  const unsigned char *m,uint64_t mlen,
   const unsigned char *n,
   const unsigned char *k
 )

--- a/src/libsodium/crypto_verify/try.c
+++ b/src/libsodium/crypto_verify/try.c
@@ -8,7 +8,7 @@
 #include "crypto_verify.h"
 #include "windows/windows-quirks.h"
 
-extern unsigned char *alignedcalloc(unsigned long long);
+extern unsigned char *alignedcalloc(uint64_t);
 
 const char *primitiveimplementation = crypto_verify_IMPLEMENTATION;
 
@@ -51,9 +51,9 @@ char checksum[2];
 
 const char *checksum_compute(void)
 {
-  long long tests;
-  long long i;
-  long long j;
+  int64_t tests;
+  int64_t i;
+  int64_t j;
   const char *c;
 
   for (tests = 0;tests < 100000;++tests) {

--- a/src/libsodium/include/sodium/crypto_auth.h
+++ b/src/libsodium/include/sodium/crypto_auth.h
@@ -2,6 +2,7 @@
 #define crypto_auth_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "crypto_auth_hmacsha512256.h"
 #include "export.h"
@@ -24,11 +25,11 @@ const char *crypto_auth_primitive(void);
 
 SODIUM_EXPORT
 int crypto_auth(unsigned char *out, const unsigned char *in,
-                unsigned long long inlen, const unsigned char *k);
+                uint64_t inlen, const unsigned char *k);
 
 SODIUM_EXPORT
 int crypto_auth_verify(const unsigned char *h, const unsigned char *in,
-                       unsigned long long inlen, const unsigned char *k);
+                       uint64_t inlen, const unsigned char *k);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_auth_hmacsha256.h
+++ b/src/libsodium/include/sodium/crypto_auth_hmacsha256.h
@@ -2,6 +2,7 @@
 #define crypto_auth_hmacsha256_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_auth_hmacsha256_BYTES 32U
@@ -21,10 +22,10 @@ SODIUM_EXPORT
 const char * crypto_auth_hmacsha256_primitive(void);
 
 SODIUM_EXPORT
-int crypto_auth_hmacsha256(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+int crypto_auth_hmacsha256(unsigned char *,const unsigned char *,uint64_t,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_auth_hmacsha256_verify(const unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+int crypto_auth_hmacsha256_verify(const unsigned char *,const unsigned char *,uint64_t,const unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_auth_hmacsha512256.h
+++ b/src/libsodium/include/sodium/crypto_auth_hmacsha512256.h
@@ -2,6 +2,7 @@
 #define crypto_auth_hmacsha512256_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_auth_hmacsha512256_BYTES 32U
@@ -21,10 +22,10 @@ SODIUM_EXPORT
 const char * crypto_auth_hmacsha512256_primitive(void);
 
 SODIUM_EXPORT
-int crypto_auth_hmacsha512256(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+int crypto_auth_hmacsha512256(unsigned char *,const unsigned char *,uint64_t,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_auth_hmacsha512256_verify(const unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+int crypto_auth_hmacsha512256_verify(const unsigned char *,const unsigned char *,uint64_t,const unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_box.h
+++ b/src/libsodium/include/sodium/crypto_box.h
@@ -9,6 +9,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "crypto_box_curve25519xsalsa20poly1305.h"
 #include "export.h"
@@ -58,22 +59,22 @@ int crypto_box_beforenm(unsigned char *k, const unsigned char *pk,
 
 SODIUM_EXPORT
 int crypto_box_afternm(unsigned char *c, const unsigned char *m,
-                       unsigned long long mlen, const unsigned char *n,
+                       uint64_t mlen, const unsigned char *n,
                        const unsigned char *k);
 
 SODIUM_EXPORT
 int crypto_box_open_afternm(unsigned char *m, const unsigned char *c,
-                            unsigned long long clen, const unsigned char *n,
+                            uint64_t clen, const unsigned char *n,
                             const unsigned char *k);
 
 SODIUM_EXPORT
 int crypto_box(unsigned char *c, const unsigned char *m,
-               unsigned long long mlen, const unsigned char *n,
+               uint64_t mlen, const unsigned char *n,
                const unsigned char *pk, const unsigned char *sk);
 
 SODIUM_EXPORT
 int crypto_box_open(unsigned char *m, const unsigned char *c,
-                    unsigned long long clen, const unsigned char *n,
+                    uint64_t clen, const unsigned char *n,
                     const unsigned char *pk, const unsigned char *sk);
 
 #ifdef __cplusplus

--- a/src/libsodium/include/sodium/crypto_box_curve25519xsalsa20poly1305.h
+++ b/src/libsodium/include/sodium/crypto_box_curve25519xsalsa20poly1305.h
@@ -2,6 +2,7 @@
 #define crypto_box_curve25519xsalsa20poly1305_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_box_curve25519xsalsa20poly1305_PUBLICKEYBYTES 32U
@@ -41,10 +42,10 @@ SODIUM_EXPORT
 const char * crypto_box_curve25519xsalsa20poly1305_primitive(void);
 
 SODIUM_EXPORT
-int crypto_box_curve25519xsalsa20poly1305(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *,const unsigned char *);
+int crypto_box_curve25519xsalsa20poly1305(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_box_curve25519xsalsa20poly1305_open(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *,const unsigned char *);
+int crypto_box_curve25519xsalsa20poly1305_open(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
 int crypto_box_curve25519xsalsa20poly1305_keypair(unsigned char *,unsigned char *);
@@ -53,10 +54,10 @@ SODIUM_EXPORT
 int crypto_box_curve25519xsalsa20poly1305_beforenm(unsigned char *,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_box_curve25519xsalsa20poly1305_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_box_curve25519xsalsa20poly1305_afternm(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_box_curve25519xsalsa20poly1305_open_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_box_curve25519xsalsa20poly1305_open_afternm(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_generichash.h
+++ b/src/libsodium/include/sodium/crypto_generichash.h
@@ -2,6 +2,7 @@
 #define crypto_generichash_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "crypto_generichash_blake2b.h"
 #include "export.h"
@@ -46,7 +47,7 @@ typedef crypto_generichash_blake2b_state crypto_generichash_state;
 
 SODIUM_EXPORT
 int crypto_generichash(unsigned char *out, size_t outlen,
-                       const unsigned char *in, unsigned long long inlen,
+                       const unsigned char *in, uint64_t inlen,
                        const unsigned char *key, size_t keylen);
 
 SODIUM_EXPORT
@@ -57,7 +58,7 @@ int crypto_generichash_init(crypto_generichash_state *state,
 SODIUM_EXPORT
 int crypto_generichash_update(crypto_generichash_state *state,
                               const unsigned char *in,
-                              unsigned long long inlen);
+                              uint64_t inlen);
 
 SODIUM_EXPORT
 int crypto_generichash_final(crypto_generichash_state *state,

--- a/src/libsodium/include/sodium/crypto_generichash_blake2b.h
+++ b/src/libsodium/include/sodium/crypto_generichash_blake2b.h
@@ -65,13 +65,13 @@ const char * crypto_generichash_blake2b_blockbytes_primitive(void);
 SODIUM_EXPORT
 int crypto_generichash_blake2b(unsigned char *out, size_t outlen,
                                const unsigned char *in,
-                               unsigned long long inlen,
+                               uint64_t inlen,
                                const unsigned char *key, size_t keylen);
 
 SODIUM_EXPORT
 int crypto_generichash_blake2b_salt_personal(unsigned char *out, size_t outlen,
                                              const unsigned char *in,
-                                             unsigned long long inlen,
+                                             uint64_t inlen,
                                              const unsigned char *key,
                                              size_t keylen,
                                              const unsigned char *salt,
@@ -92,7 +92,7 @@ int crypto_generichash_blake2b_init_salt_personal(crypto_generichash_blake2b_sta
 SODIUM_EXPORT
 int crypto_generichash_blake2b_update(crypto_generichash_blake2b_state *state,
                                       const unsigned char *in,
-                                      unsigned long long inlen);
+                                      uint64_t inlen);
 
 SODIUM_EXPORT
 int crypto_generichash_blake2b_final(crypto_generichash_blake2b_state *state,

--- a/src/libsodium/include/sodium/crypto_hash.h
+++ b/src/libsodium/include/sodium/crypto_hash.h
@@ -14,7 +14,7 @@ extern "C" {
 
 SODIUM_EXPORT
 int crypto_hash(unsigned char *out, const unsigned char *in,
-                unsigned long long inlen);
+                uint64_t inlen);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_hash_sha256.h
+++ b/src/libsodium/include/sodium/crypto_hash_sha256.h
@@ -2,6 +2,7 @@
 #define crypto_hash_sha256_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_hash_sha256_BYTES 32U
@@ -18,7 +19,7 @@ SODIUM_EXPORT
 const char * crypto_hash_sha256_primitive(void);
 
 SODIUM_EXPORT
-int crypto_hash_sha256(unsigned char *,const unsigned char *,unsigned long long);
+int crypto_hash_sha256(unsigned char *,const unsigned char *,uint64_t);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_hash_sha512.h
+++ b/src/libsodium/include/sodium/crypto_hash_sha512.h
@@ -2,6 +2,7 @@
 #define crypto_hash_sha512_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_hash_sha512_BYTES 64U
@@ -18,7 +19,7 @@ SODIUM_EXPORT
 const char * crypto_hash_sha512_primitive(void);
 
 SODIUM_EXPORT
-int crypto_hash_sha512(unsigned char *,const unsigned char *,unsigned long long);
+int crypto_hash_sha512(unsigned char *,const unsigned char *,uint64_t);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_hashblocks_sha256.h
+++ b/src/libsodium/include/sodium/crypto_hashblocks_sha256.h
@@ -2,6 +2,7 @@
 #define crypto_hashblocks_sha256_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_hashblocks_sha256_STATEBYTES 32U
@@ -21,7 +22,7 @@ SODIUM_EXPORT
 const char * crypto_hashblocks_sha256_primitive(void);
 
 SODIUM_EXPORT
-int crypto_hashblocks_sha256(unsigned char *,const unsigned char *,unsigned long long);
+int crypto_hashblocks_sha256(unsigned char *,const unsigned char *,uint64_t);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_hashblocks_sha512.h
+++ b/src/libsodium/include/sodium/crypto_hashblocks_sha512.h
@@ -2,6 +2,7 @@
 #define crypto_hashblocks_sha512_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_hashblocks_sha512_STATEBYTES 64U
@@ -21,7 +22,7 @@ SODIUM_EXPORT
 const char * crypto_hashblocks_sha512_primitive(void);
 
 SODIUM_EXPORT
-int crypto_hashblocks_sha512(unsigned char *,const unsigned char *,unsigned long long);
+int crypto_hashblocks_sha512(unsigned char *,const unsigned char *,uint64_t);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_onetimeauth.h
+++ b/src/libsodium/include/sodium/crypto_onetimeauth.h
@@ -2,6 +2,7 @@
 #define crypto_onetimeauth_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "crypto_onetimeauth_poly1305.h"
 #include "export.h"
@@ -24,11 +25,11 @@ const char *crypto_onetimeauth_primitive(void);
 
 SODIUM_EXPORT
 int crypto_onetimeauth(unsigned char *out, const unsigned char *in,
-                       unsigned long long inlen, const unsigned char *k);
+                       uint64_t inlen, const unsigned char *k);
 
 SODIUM_EXPORT
 int crypto_onetimeauth_verify(const unsigned char *h, const unsigned char *in,
-                              unsigned long long inlen, const unsigned char *k);
+                              uint64_t inlen, const unsigned char *k);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_onetimeauth_poly1305.h
+++ b/src/libsodium/include/sodium/crypto_onetimeauth_poly1305.h
@@ -2,6 +2,7 @@
 #define crypto_onetimeauth_poly1305_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_onetimeauth_poly1305_BYTES 16U
@@ -19,11 +20,11 @@ typedef struct crypto_onetimeauth_poly1305_implementation {
     const char *(*implementation_name)(void);
     int         (*onetimeauth)(unsigned char *out,
                                const unsigned char *in,
-                               unsigned long long inlen,
+                               uint64_t inlen,
                                const unsigned char *k);
     int         (*onetimeauth_verify)(const unsigned char *h,
                                       const unsigned char *in,
-                                      unsigned long long inlen,
+                                      uint64_t inlen,
                                       const unsigned char *k);
 } crypto_onetimeauth_poly1305_implementation;
 
@@ -49,13 +50,13 @@ crypto_onetimeauth_poly1305_implementation *
 SODIUM_EXPORT
 int crypto_onetimeauth_poly1305(unsigned char *out,
                                 const unsigned char *in,
-                                unsigned long long inlen,
+                                uint64_t inlen,
                                 const unsigned char *k);
 
 SODIUM_EXPORT
 int crypto_onetimeauth_poly1305_verify(const unsigned char *h,
                                        const unsigned char *in,
-                                       unsigned long long inlen,
+                                       uint64_t inlen,
                                        const unsigned char *k);
 
 #ifdef __cplusplus

--- a/src/libsodium/include/sodium/crypto_onetimeauth_poly1305_53.h
+++ b/src/libsodium/include/sodium/crypto_onetimeauth_poly1305_53.h
@@ -18,13 +18,13 @@ const char *crypto_onetimeauth_poly1305_53_implementation_name(void);
 SODIUM_EXPORT
 int crypto_onetimeauth_poly1305_53(unsigned char *out,
                                    const unsigned char *in,
-                                   unsigned long long inlen,
+                                   uint64_t inlen,
                                    const unsigned char *k);
 
 SODIUM_EXPORT
 int crypto_onetimeauth_poly1305_53_verify(const unsigned char *h,
                                           const unsigned char *in,
-                                          unsigned long long inlen,
+                                          uint64_t inlen,
                                           const unsigned char *k);
 
 #ifdef __cplusplus

--- a/src/libsodium/include/sodium/crypto_onetimeauth_poly1305_donna.h
+++ b/src/libsodium/include/sodium/crypto_onetimeauth_poly1305_donna.h
@@ -18,13 +18,13 @@ const char *crypto_onetimeauth_poly1305_donna_implementation_name(void);
 SODIUM_EXPORT
 int crypto_onetimeauth_poly1305_donna(unsigned char *out,
                                       const unsigned char *in,
-                                      unsigned long long inlen,
+                                      uint64_t inlen,
                                       const unsigned char *k);
 
 SODIUM_EXPORT
 int crypto_onetimeauth_poly1305_donna_verify(const unsigned char *h,
                                              const unsigned char *in,
-                                             unsigned long long inlen,
+                                             uint64_t inlen,
                                              const unsigned char *k);
 
 #ifdef __cplusplus

--- a/src/libsodium/include/sodium/crypto_secretbox.h
+++ b/src/libsodium/include/sodium/crypto_secretbox.h
@@ -2,6 +2,7 @@
 #define crypto_secretbox_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "crypto_secretbox_xsalsa20poly1305.h"
 #include "export.h"
@@ -36,12 +37,12 @@ const char *crypto_secretbox_primitive(void);
 
 SODIUM_EXPORT
 int crypto_secretbox(unsigned char *c, const unsigned char *m,
-                     unsigned long long mlen, const unsigned char *n,
+                     uint64_t mlen, const unsigned char *n,
                      const unsigned char *k);
 
 SODIUM_EXPORT
 int crypto_secretbox_open(unsigned char *m, const unsigned char *c,
-                          unsigned long long clen, const unsigned char *n,
+                          uint64_t clen, const unsigned char *n,
                           const unsigned char *k);
 
 #ifdef __cplusplus

--- a/src/libsodium/include/sodium/crypto_secretbox_xsalsa20poly1305.h
+++ b/src/libsodium/include/sodium/crypto_secretbox_xsalsa20poly1305.h
@@ -2,6 +2,7 @@
 #define crypto_secretbox_xsalsa20poly1305_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_secretbox_xsalsa20poly1305_KEYBYTES 32U
@@ -33,10 +34,10 @@ SODIUM_EXPORT
 const char * crypto_secretbox_xsalsa20poly1305_primitive(void);
 
 SODIUM_EXPORT
-int crypto_secretbox_xsalsa20poly1305(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_secretbox_xsalsa20poly1305(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_secretbox_xsalsa20poly1305_open(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_secretbox_xsalsa20poly1305_open(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_shorthash.h
+++ b/src/libsodium/include/sodium/crypto_shorthash.h
@@ -2,6 +2,7 @@
 #define crypto_shorthash_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "crypto_shorthash_siphash24.h"
 #include "export.h"
@@ -24,7 +25,7 @@ const char *crypto_shorthash_primitive(void);
 
 SODIUM_EXPORT
 int crypto_shorthash(unsigned char *out, const unsigned char *in,
-                     unsigned long long inlen, const unsigned char *k);
+                     uint64_t inlen, const unsigned char *k);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_shorthash_siphash24.h
+++ b/src/libsodium/include/sodium/crypto_shorthash_siphash24.h
@@ -2,6 +2,7 @@
 #define crypto_shorthash_siphash24_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_shorthash_siphash24_BYTES 8U
@@ -18,7 +19,7 @@ SODIUM_EXPORT
 const char * crypto_shorthash_siphash24_primitive(void);
 
 SODIUM_EXPORT
-int crypto_shorthash_siphash24(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+int crypto_shorthash_siphash24(unsigned char *,const unsigned char *,uint64_t,const unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_sign.h
+++ b/src/libsodium/include/sodium/crypto_sign.h
@@ -9,6 +9,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "crypto_sign_ed25519.h"
 #include "export.h"
@@ -45,13 +46,13 @@ SODIUM_EXPORT
 int crypto_sign_keypair(unsigned char *pk, unsigned char *sk);
 
 SODIUM_EXPORT
-int crypto_sign(unsigned char *sm, unsigned long long *smlen,
-                const unsigned char *m, unsigned long long mlen,
+int crypto_sign(unsigned char *sm, uint64_t *smlen,
+                const unsigned char *m, uint64_t mlen,
                 const unsigned char *sk);
 
 SODIUM_EXPORT
-int crypto_sign_open(unsigned char *m, unsigned long long *mlen,
-                     const unsigned char *sm, unsigned long long smlen,
+int crypto_sign_open(unsigned char *m, uint64_t *mlen,
+                     const unsigned char *sm, uint64_t smlen,
                      const unsigned char *pk);
 
 #ifdef __cplusplus

--- a/src/libsodium/include/sodium/crypto_sign_ed25519.h
+++ b/src/libsodium/include/sodium/crypto_sign_ed25519.h
@@ -2,6 +2,7 @@
 #define crypto_sign_ed25519_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_sign_ed25519_SECRETKEYBYTES 64U
@@ -29,10 +30,10 @@ SODIUM_EXPORT
 const char * crypto_sign_ed25519_primitive(void);
 
 SODIUM_EXPORT
-int crypto_sign_ed25519(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
+int crypto_sign_ed25519(unsigned char *,uint64_t *,const unsigned char *,uint64_t,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_sign_ed25519_open(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
+int crypto_sign_ed25519_open(unsigned char *,uint64_t *,const unsigned char *,uint64_t,const unsigned char *);
 
 SODIUM_EXPORT
 int crypto_sign_ed25519_keypair(unsigned char *,unsigned char *);

--- a/src/libsodium/include/sodium/crypto_sign_edwards25519sha512batch.h
+++ b/src/libsodium/include/sodium/crypto_sign_edwards25519sha512batch.h
@@ -2,6 +2,7 @@
 #define crypto_sign_edwards25519sha512batch_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_sign_edwards25519sha512batch_SECRETKEYBYTES 64U
@@ -25,10 +26,10 @@ SODIUM_EXPORT
 const char * crypto_sign_edwards25519sha512batch_primitive(void);
 
 SODIUM_EXPORT
-int crypto_sign_edwards25519sha512batch(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
+int crypto_sign_edwards25519sha512batch(unsigned char *,uint64_t *,const unsigned char *,uint64_t,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_sign_edwards25519sha512batch_open(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
+int crypto_sign_edwards25519sha512batch_open(unsigned char *,uint64_t *,const unsigned char *,uint64_t,const unsigned char *);
 
 SODIUM_EXPORT
 int crypto_sign_edwards25519sha512batch_keypair(unsigned char *,unsigned char *);

--- a/src/libsodium/include/sodium/crypto_stream.h
+++ b/src/libsodium/include/sodium/crypto_stream.h
@@ -10,6 +10,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "crypto_stream_xsalsa20.h"
 #include "export.h"
@@ -31,12 +32,12 @@ SODIUM_EXPORT
 const char *crypto_stream_primitive(void);
 
 SODIUM_EXPORT
-int crypto_stream(unsigned char *c, unsigned long long clen,
+int crypto_stream(unsigned char *c, uint64_t clen,
                   const unsigned char *n, const unsigned char *k);
 
 SODIUM_EXPORT
 int crypto_stream_xor(unsigned char *c, const unsigned char *m,
-                      unsigned long long mlen, const unsigned char *n,
+                      uint64_t mlen, const unsigned char *n,
                       const unsigned char *k);
 
 #ifdef __cplusplus

--- a/src/libsodium/include/sodium/crypto_stream_aes128ctr.h
+++ b/src/libsodium/include/sodium/crypto_stream_aes128ctr.h
@@ -10,6 +10,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_stream_aes128ctr_KEYBYTES 16U
@@ -33,19 +34,19 @@ SODIUM_EXPORT
 const char * crypto_stream_aes128ctr_primitive(void);
 
 SODIUM_EXPORT
-int crypto_stream_aes128ctr(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_aes128ctr(unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_aes128ctr_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_aes128ctr_xor(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
 int crypto_stream_aes128ctr_beforenm(unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_aes128ctr_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_aes128ctr_afternm(unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_aes128ctr_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_aes128ctr_xor_afternm(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_stream_aes256estream.h
+++ b/src/libsodium/include/sodium/crypto_stream_aes256estream.h
@@ -11,6 +11,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_stream_aes256estream_KEYBYTES 32U
@@ -34,19 +35,19 @@ SODIUM_EXPORT
 const char * crypto_stream_aes256estream_primitive(void);
 
 SODIUM_EXPORT
-int crypto_stream_aes256estream(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_aes256estream(unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_aes256estream_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_aes256estream_xor(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
 int crypto_stream_aes256estream_beforenm(unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_aes256estream_afternm(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_aes256estream_afternm(unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_aes256estream_xor_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_aes256estream_xor_afternm(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_stream_salsa2012.h
+++ b/src/libsodium/include/sodium/crypto_stream_salsa2012.h
@@ -10,6 +10,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #ifdef __cplusplus
@@ -28,10 +29,10 @@ SODIUM_EXPORT
 const char * crypto_stream_salsa2012_primitive(void);
 
 SODIUM_EXPORT
-int crypto_stream_salsa2012(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_salsa2012(unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_salsa2012_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_salsa2012_xor(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_stream_salsa208.h
+++ b/src/libsodium/include/sodium/crypto_stream_salsa208.h
@@ -10,6 +10,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #ifdef __cplusplus
@@ -28,10 +29,10 @@ SODIUM_EXPORT
 const char * crypto_stream_salsa208_primitive(void);
 
 SODIUM_EXPORT
-int crypto_stream_salsa208(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_salsa208(unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_salsa208_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_salsa208_xor(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/crypto_stream_xsalsa20.h
+++ b/src/libsodium/include/sodium/crypto_stream_xsalsa20.h
@@ -10,6 +10,7 @@
  */
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #define crypto_stream_xsalsa20_KEYBYTES 32U
@@ -29,10 +30,10 @@ SODIUM_EXPORT
 const char * crypto_stream_xsalsa20_primitive(void);
 
 SODIUM_EXPORT
-int crypto_stream_xsalsa20(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_xsalsa20(unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 SODIUM_EXPORT
-int crypto_stream_xsalsa20_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+int crypto_stream_xsalsa20_xor(unsigned char *,const unsigned char *,uint64_t,const unsigned char *,const unsigned char *);
 
 #ifdef __cplusplus
 }

--- a/src/libsodium/include/sodium/randombytes.h
+++ b/src/libsodium/include/sodium/randombytes.h
@@ -26,7 +26,7 @@ SODIUM_EXPORT
 int         randombytes_set_implementation(randombytes_implementation *impl);
 
 SODIUM_EXPORT
-void        randombytes(unsigned char * const buf, const unsigned long long buf_len);
+void        randombytes(unsigned char * const buf, const uint64_t buf_len);
 
 SODIUM_EXPORT
 const char *randombytes_implementation_name(void);

--- a/src/libsodium/randombytes/randombytes.c
+++ b/src/libsodium/randombytes/randombytes.c
@@ -58,7 +58,7 @@ randombytes_close(void)
 }
 
 void
-randombytes(unsigned char * const buf, const unsigned long long buf_len)
+randombytes(unsigned char * const buf, const uint64_t buf_len)
 {
     assert(buf_len <= SIZE_MAX);
     randombytes_buf(buf, (size_t) buf_len);

--- a/src/libsodium/randombytes/salsa20/randombytes_salsa20_random.c
+++ b/src/libsodium/randombytes/salsa20/randombytes_salsa20_random.c
@@ -220,7 +220,7 @@ randombytes_salsa20_random_getword(void)
         randombytes_salsa20_random_stir_if_needed();
         COMPILER_ASSERT(sizeof stream.nonce == crypto_stream_salsa20_NONCEBYTES);
         ret = crypto_stream_salsa20((unsigned char *) stream.rnd32,
-                                    (unsigned long long) sizeof stream.rnd32,
+                                    (uint64_t) sizeof stream.rnd32,
                                     (unsigned char *) &stream.nonce,
                                     stream.key);
         assert(ret == 0);
@@ -271,7 +271,7 @@ randombytes_salsa20_random_buf(void * const buf, const size_t size)
 #ifdef ULONG_LONG_MAX
     assert(size <= ULONG_LONG_MAX);
 #endif
-    ret = crypto_stream_salsa20((unsigned char *) buf, (unsigned long long) size,
+    ret = crypto_stream_salsa20((unsigned char *) buf, (uint64_t) size,
                                 (unsigned char *) &stream.nonce,
                                 stream.key);
     assert(ret == 0);

--- a/src/libsodium/sodium/compat.c
+++ b/src/libsodium/sodium/compat.c
@@ -20,7 +20,7 @@ extern "C" {
 #undef crypto_hash_sha256_ref
 SODIUM_EXPORT int
 crypto_hash_sha256_ref(unsigned char *out, const unsigned char *in,
-                       unsigned long long inlen)
+                       uint64_t inlen)
 {
     return crypto_hash_sha256(out, in, inlen);
 }
@@ -28,7 +28,7 @@ crypto_hash_sha256_ref(unsigned char *out, const unsigned char *in,
 #undef crypto_hash_sha512_ref
 SODIUM_EXPORT int
 crypto_hash_sha512_ref(unsigned char *out, const unsigned char *in,
-                       unsigned long long inlen)
+                       uint64_t inlen)
 {
     return crypto_hash_sha512(out, in, inlen);
 }
@@ -36,7 +36,7 @@ crypto_hash_sha512_ref(unsigned char *out, const unsigned char *in,
 #undef crypto_auth_hmacsha256_ref
 SODIUM_EXPORT int
 crypto_auth_hmacsha256_ref(unsigned char *out, const unsigned char *in,
-                           unsigned long long inlen, const unsigned char *k)
+                           uint64_t inlen, const unsigned char *k)
 {
     return crypto_auth_hmacsha256(out, in, inlen, k);
 }
@@ -45,7 +45,7 @@ crypto_auth_hmacsha256_ref(unsigned char *out, const unsigned char *in,
 SODIUM_EXPORT int
 crypto_auth_hmacsha256_ref_verify(const unsigned char *h,
                                   const unsigned char *in,
-                                  unsigned long long inlen,
+                                  uint64_t inlen,
                                   const unsigned char *k)
 {
     return crypto_auth_hmacsha256_verify(h, in, inlen, k);
@@ -54,7 +54,7 @@ crypto_auth_hmacsha256_ref_verify(const unsigned char *h,
 #undef crypto_auth_hmacsha512256_ref
 SODIUM_EXPORT int
 crypto_auth_hmacsha512256_ref(unsigned char *out, const unsigned char *in,
-                              unsigned long long inlen, const unsigned char *k)
+                              uint64_t inlen, const unsigned char *k)
 {
     return crypto_auth_hmacsha512256(out, in, inlen, k);
 }
@@ -63,7 +63,7 @@ crypto_auth_hmacsha512256_ref(unsigned char *out, const unsigned char *in,
 SODIUM_EXPORT int
 crypto_auth_hmacsha512256_ref_verify(const unsigned char *h,
                                      const unsigned char *in,
-                                     unsigned long long inlen,
+                                     uint64_t inlen,
                                      const unsigned char *k)
 {
     return crypto_auth_hmacsha512256_verify(h, in, inlen, k);
@@ -90,7 +90,7 @@ crypto_box_curve25519xsalsa20poly1305_ref_beforenm(unsigned char *k,
 SODIUM_EXPORT int
 crypto_box_curve25519xsalsa20poly1305_ref_afternm(unsigned char *c,
                                                   const unsigned char *m,
-                                                  unsigned long long mlen,
+                                                  uint64_t mlen,
                                                   const unsigned char *n,
                                                   const unsigned char *k)
 {
@@ -101,7 +101,7 @@ crypto_box_curve25519xsalsa20poly1305_ref_afternm(unsigned char *c,
 SODIUM_EXPORT int
 crypto_box_curve25519xsalsa20poly1305_ref_open_afternm(unsigned char *m,
                                                        const unsigned char *c,
-                                                       unsigned long long clen,
+                                                       uint64_t clen,
                                                        const unsigned char *n,
                                                        const unsigned char *k)
 {
@@ -112,7 +112,7 @@ crypto_box_curve25519xsalsa20poly1305_ref_open_afternm(unsigned char *m,
 SODIUM_EXPORT int
 crypto_box_curve25519xsalsa20poly1305_ref(unsigned char *c,
                                           const unsigned char *m,
-                                          unsigned long long mlen,
+                                          uint64_t mlen,
                                           const unsigned char *n,
                                           const unsigned char *pk,
                                           const unsigned char *sk)
@@ -124,7 +124,7 @@ crypto_box_curve25519xsalsa20poly1305_ref(unsigned char *c,
 SODIUM_EXPORT int
 crypto_box_curve25519xsalsa20poly1305_ref_open(unsigned char *m,
                                                const unsigned char *c,
-                                               unsigned long long clen,
+                                               uint64_t clen,
                                                const unsigned char *n,
                                                const unsigned char *pk,
                                                const unsigned char *sk)
@@ -151,7 +151,7 @@ crypto_scalarmult_curve25519_ref(unsigned char *q, const unsigned char *n,
 SODIUM_EXPORT int
 crypto_secretbox_xsalsa20poly1305_ref(unsigned char *c,
                                       const unsigned char *m,
-                                      unsigned long long mlen,
+                                      uint64_t mlen,
                                       const unsigned char *n,
                                       const unsigned char *k)
 {
@@ -162,7 +162,7 @@ crypto_secretbox_xsalsa20poly1305_ref(unsigned char *c,
 SODIUM_EXPORT int
 crypto_secretbox_xsalsa20poly1305_ref_open(unsigned char *m,
                                            const unsigned char *c,
-                                           unsigned long long clen,
+                                           uint64_t clen,
                                            const unsigned char *n,
                                            const unsigned char *k)
 {
@@ -186,8 +186,8 @@ crypto_sign_ed25519_ref_keypair(unsigned char *pk, unsigned char *sk)
 
 #undef crypto_sign_ed25519_ref
 SODIUM_EXPORT int
-crypto_sign_ed25519_ref(unsigned char *sm, unsigned long long *smlen,
-                        const unsigned char *m, unsigned long long mlen,
+crypto_sign_ed25519_ref(unsigned char *sm, uint64_t *smlen,
+                        const unsigned char *m, uint64_t mlen,
                         const unsigned char *sk)
 {
     return crypto_sign_ed25519(sm, smlen, m, mlen, sk);
@@ -195,8 +195,8 @@ crypto_sign_ed25519_ref(unsigned char *sm, unsigned long long *smlen,
 
 #undef crypto_sign_ed25519_ref_open
 SODIUM_EXPORT int
-crypto_sign_ed25519_ref_open(unsigned char *m, unsigned long long *mlen,
-                             const unsigned char *sm, unsigned long long smlen,
+crypto_sign_ed25519_ref_open(unsigned char *m, uint64_t *mlen,
+                             const unsigned char *sm, uint64_t smlen,
                              const unsigned char *pk)
 {
     return crypto_sign_ed25519_open(m, mlen, sm, smlen, pk);
@@ -204,7 +204,7 @@ crypto_sign_ed25519_ref_open(unsigned char *m, unsigned long long *mlen,
 
 #undef crypto_stream_xsalsa20_ref
 SODIUM_EXPORT int
-crypto_stream_xsalsa20_ref(unsigned char *c, unsigned long long clen,
+crypto_stream_xsalsa20_ref(unsigned char *c, uint64_t clen,
                            const unsigned char *n, const unsigned char *k)
 {
     return crypto_stream_xsalsa20(c, clen, n, k);
@@ -213,7 +213,7 @@ crypto_stream_xsalsa20_ref(unsigned char *c, unsigned long long clen,
 #undef crypto_stream_xsalsa20_ref_xor
 SODIUM_EXPORT int
 crypto_stream_xsalsa20_ref_xor(unsigned char *c, const unsigned char *m,
-                               unsigned long long mlen, const unsigned char *n,
+                               uint64_t mlen, const unsigned char *n,
                                const unsigned char *k)
 {
     return crypto_stream_xsalsa20_xor(c, m, mlen, n, k);
@@ -237,7 +237,7 @@ crypto_verify_32_ref(const unsigned char *x, const unsigned char *y)
 SODIUM_EXPORT int
 crypto_onetimeauth_poly1305_ref(unsigned char *out,
                                 const unsigned char *in,
-                                unsigned long long inlen,
+                                uint64_t inlen,
                                 const unsigned char *k)
 {
     return crypto_onetimeauth_poly1305(out, in, inlen, k);


### PR DESCRIPTION
- renamed "long long" to int64_t
- renamed "unsigned long long" to uint64_t
- include <stdint.h> in every header after <stddef.h>
- make check passes (on 64 bit Linux)

So you can't include them from a C++98 program with -pedantic -Werror
