### PR TITLE
stream_salsa20: amd64: correctly define symbol types

### DIFF
--- a/src/libsodium/crypto_stream/salsa20/amd64_xmm6/stream_salsa20_amd64_xmm6.S
+++ b/src/libsodium/crypto_stream/salsa20/amd64_xmm6/stream_salsa20_amd64_xmm6.S
@@ -3,9 +3,11 @@
 .text
 .p2align 5
 
-.globl _crypto_stream_salsa20
+#ifdef __ELF__
+.type crypto_stream_salsa20 STT_FUNC
+#endif
+
 .globl crypto_stream_salsa20
-_crypto_stream_salsa20:
 crypto_stream_salsa20:
 mov %rsp,%r11
 and $31,%r11
@@ -35,9 +37,11 @@ jmp ._start
 .text
 .p2align 5
 
-.globl _crypto_stream_salsa20_xor
+#ifdef __ELF__
+.type crypto_stream_salsa20_xor STT_FUNC
+#endif
+
 .globl crypto_stream_salsa20_xor
-_crypto_stream_salsa20_xor:
 crypto_stream_salsa20_xor:
 mov %rsp,%r11
 and $31,%r11


### PR DESCRIPTION
The crypto_stream_salsa20{,_xor} functions are broken on amd64 if libsodium is used as a shared library, as the symbol types in the assembly implementation aren't defined. This causes different warnings (depending on the toolchain used) during linking and/or runtime when you build a program using them, and leads to a segfault when trying to call them.

This patch fixes the problem.
