### PR TITLE
Repair broken sonames

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,13 +151,13 @@ AX_CHECK_COMPILE_FLAG([-fwrapv], [CFLAGS="$CFLAGS -fwrapv"])
 AX_CHECK_COMPILE_FLAG([-fno-strict-aliasing], [CFLAGS="$CFLAGS -fno-strict-aliasing"])
 AX_CHECK_COMPILE_FLAG([-fno-strict-overflow], [CFLAGS="$CFLAGS -fno-strict-overflow"])
 
+LIBTOOL_OLD_FLAGS="$LIBTOOL_EXTRA_FLAGS"
+LIBTOOL_EXTRA_FLAGS="$LIBTOOL_EXTRA_FLAGS -version-info $SODIUM_LIBRARY_VERSION"
 AC_ARG_ENABLE(soname-versions,
   [AC_HELP_STRING([--enable-soname-versions], [enable soname versions (must be disabled for android) (default: enabled)])],
     [
 	AS_IF([test "x$enableval" = "xno"], [
-          LIBTOOL_EXTRA_FLAGS="$LIBTOOL_EXTRA_FLAGS -avoid-version"
-        ], [
-          LIBTOOL_EXTRA_FLAGS="$LIBTOOL_EXTRA_FLAGS -version-info $SODIUM_LIBRARY_VERSION"
+          LIBTOOL_EXTRA_FLAGS="$LIBTOOL_OLD_FLAGS -avoid-version"
         ])
     ]
 )


### PR DESCRIPTION
I'm sorry I didn't notice this when I sent my first pull request regarding this, but apparently I broke soname support with it. Instead of the correct soname libsodium.4, the soname was libsodium.0 when building with sonames enabled. Similarly, the symlinks were set to libsodium.0, libsodium.0.0 and libsodium.0.0.0.

This commit fixes this problem while retaining the --disable-soname-versions functionality.

I have no idea WHY I broke it, but this fixes the problem. Maybe my old pull request was not a valid if/else block? Who knows. configure.ac syntax is confusing.

Again, I'm very sorry and would like to apologize to everyone who experienced a build with a broken soname in the meantime.
