### PR TITLE
Introduce a --disable-sse switch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,20 @@ LX_CFLAGS=${CFLAGS-NONE}
 
 dnl Switches
 
+AC_ARG_ENABLE(sse,
+[AC_HELP_STRING(--disable-sse,disable SSE optimizations)],
+[
+  AS_IF([test "x$enableval" = "xno"], [
+    enable_sse="no"
+  ], [
+    enable_sse="yes"
+  ])
+],
+[
+  enable_sse="yes"
+])
+AM_CONDITIONAL([HAVE_SSE], [test "x$enable_sse" != "xno"])
+
 AC_ARG_ENABLE(ssp,
 [AS_HELP_STRING(--disable-ssp,Do not compile with -fstack-protector)],
 [

--- a/src/libsodium/Makefile.am
+++ b/src/libsodium/Makefile.am
@@ -67,7 +67,6 @@ libsodium_la_SOURCES = \
 	crypto_pwhash/scryptxsalsa208sha256/pbkdf2-sha256.h \
 	crypto_pwhash/scryptxsalsa208sha256/sysendian.h \
 	crypto_pwhash/scryptxsalsa208sha256/nosse/pwhash_scryptxsalsa208sha256.c \
-	crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c \
 	crypto_scalarmult/crypto_scalarmult.c \
 	crypto_scalarmult/curve25519/scalarmult_curve25519_api.c \
 	crypto_secretbox/crypto_secretbox.c \
@@ -196,6 +195,11 @@ libsodium_la_SOURCES = \
 	sodium/core.c \
 	sodium/utils.c \
 	sodium/version.c
+
+if HAVE_SSE
+libsodium_la_SOURCES += \
+	crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c
+endif
 
 if HAVE_TI_MODE
 libsodium_la_SOURCES += \


### PR DESCRIPTION
Attempting to compile the library on a MIPS-based system causes the build to fail with the following message:

```
  CC       crypto_pwhash/scryptxsalsa208sha256/sse/libsodium_la-pwhash_scryptxsalsa208sha256.lo
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:31:23: error: emmintrin.h: No such file or directory
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:105: warning: type defaults to 'int' in declaration of '__m128i'
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:105: error: expected ';', ',' or ')' before '*' token
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:156: warning: type defaults to 'int' in declaration of '__m128i'
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:156: error: expected ';', ',' or ')' before '*' token
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c: In function 'smix':
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:226: error: '__m128i' undeclared (first use in this function)
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:226: error: (Each undeclared identifier is reported only once
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:226: error: for each function it appears in.)
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:226: error: 'X' undeclared (first use in this function)
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:226: error: expected expression before ')' token
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:244: error: 'Y' undeclared (first use in this function)
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:244: error: expected expression before ')' token
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:245: warning: implicit declaration of function 'blockmix_salsa8'
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:249: error: expected expression before ')' token
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:255: error: expected expression before ')' token
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:260: error: expected expression before ')' token
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:264: error: expected expression before ')' token
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:271: error: 'V_j' undeclared (first use in this function)
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:271: error: expected expression before ')' token
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:275: warning: implicit declaration of function 'blockmix_salsa8_xor'
crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c:276: error: expected expression before ')' token
*** Error code 1
```

Introducing a `--disable-sse` flag and not compiling `scryptxsalsa208sha256/sse/libsodium_la-pwhash_scryptxsalsa208sha256` when it is set is a workaround for the issue (at least until CPU detection is introduced in the build scripts).

As a side note, all the tests fail with an `exec: x: Exec format error` when built with `make check`. For some reason they are getting compiled as shared objects but I haven't been able to track down why. They run fine when built manually.
