### PR TITLE
Check r and p against zero before dividing

### DIFF
--- a/src/libsodium/crypto_pwhash/scryptxsalsa208sha256/nosse/pwhash_scryptxsalsa208sha256.c
+++ b/src/libsodium/crypto_pwhash/scryptxsalsa208sha256/nosse/pwhash_scryptxsalsa208sha256.c
@@ -248,6 +248,10 @@ escrypt_kdf_nosse(escrypt_local_t * local,
 		errno = EINVAL;
 		return -1;
 	}
+	if (r == 0 || p == 0) {
+		errno = EINVAL;
+		return -1;
+	}
 	if ((r > SIZE_MAX / 128 / p) ||
 #if SIZE_MAX / 256 <= UINT32_MAX
 	    (r > SIZE_MAX / 256) ||

--- a/src/libsodium/crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c
+++ b/src/libsodium/crypto_pwhash/scryptxsalsa208sha256/sse/pwhash_scryptxsalsa208sha256.c
@@ -334,6 +334,10 @@ escrypt_kdf_sse(escrypt_local_t * local,
 		errno = EINVAL;
 		return -1;
 	}
+	if (r == 0 || p == 0) {
+		errno = EINVAL;
+		return -1;
+	}
 	if ((r > SIZE_MAX / 128 / p) ||
 #if SIZE_MAX / 256 <= UINT32_MAX
 	    (r > SIZE_MAX / 256) ||


### PR DESCRIPTION
These can be zero through a hash in crypto_pwhash_scryptxsalsa208sha256_str_verify and are never checked, leading to SIGFPE due to dividing by zero.
