### PR TITLE
Fix memset_s detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -380,7 +380,7 @@ AS_CASE([$host_cpu],
 )
 
 AC_MSG_CHECKING(for memset_s)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <string.h>
 ]], [[
 char dummy[42];


### PR DESCRIPTION
Hi,

WIth mingw the memset_s detection is not severe enough:

conftest.c: In function 'main':
conftest.c:41:1: warning: implicit declaration of function 'memset_s' [-Wimplicit-function-declaration](void) memset_s(dummy, (rsize_t) sizeof dummy, 0, (rsize_t) sizeof dummy);

I had to test the link to test memset_s availability.
