### PR TITLE
prevented 128 bit integers from compiling with emscripten

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -339,6 +339,10 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #ifndef NATIVE_LITTLE_ENDIAN
 # error donna_c64 currently requires a little endian CPU
 #endif
+#ifdef EMSCRIPTEN
+# error emscripten currently supports only shift operations on integers \
+#       larger than 64 bits
+#endif
 #include <stdint.h>
 typedef unsigned uint128_t __attribute__((mode(TI)));
 void fcontract(uint128_t *t) {


### PR DESCRIPTION
When was the last time you compiled the library with Emscripten?

Everything is working fine now and the Javascript demo should be out soon.
