### PR TITLE
Added ./autogen.sh to installation commands

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,6 +50,7 @@ Download a
 [tarball of libsodium](https://download.libsodium.org/libsodium/releases/),
 then follow the ritual:
 
+    ./autogen.sh
     ./configure
     make && make check && make install
 


### PR DESCRIPTION
The docs for installation are missing a reference to `autogen.sh` which is required to build the `configure` script mentioned as the first build step.
