### PR TITLE
Added sudo command before make install

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -51,7 +51,9 @@ Download a
 then follow the ritual:
 
     ./configure
-    make && make check && make install
+    make
+    make check
+    sudo make install
 
 Pre-compiled Win32 packages are available for download at the same
 location.


### PR DESCRIPTION
The install mantra is `make && make check && make install` which build the library, tests and installs.  However, if the current user does not have root privileges, the install will fail.  The change breaks the steps into separate commands and puts `sudo` in front of the `make install` so that the user is prompted for password if needed.
