### PR TITLE
fixed crypto_box_open_easy allocating more memory than it needed

### DIFF
--- a/src/libsodium/crypto_box/crypto_box_easy.c
+++ b/src/libsodium/crypto_box/crypto_box_easy.c
@@ -72,7 +72,7 @@ crypto_box_open_easy(unsigned char *m, const unsigned char *c,
     }
     memset(c_boxed, 0, crypto_box_BOXZEROBYTES);
     memcpy(c_boxed + crypto_box_BOXZEROBYTES, c, clen);
-    m_boxed_len = c_boxed_len;
+    m_boxed_len = (clen - crypto_box_MACBYTES) + crypto_box_ZEROBYTES;
     if ((m_boxed = (unsigned char *) malloc(m_boxed_len)) == NULL) {
         free(c_boxed);
         return -1;


### PR DESCRIPTION
m_boxed_len and c_boxed_len should be the same
