### PR TITLE
Fixes VS 2008 build.

### DIFF
--- a/builds/msvc/vs2010/libsodium/libsodium.props
+++ b/builds/msvc/vs2010/libsodium/libsodium.props
@@ -25,7 +25,7 @@
       <EnablePREfast>false</EnablePREfast>
       <PreprocessorDefinitions>inline=__inline;NATIVE_LITTLE_ENDIAN;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'StaticLibrary'">SODIUM_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">SODIUM_DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-amd64asm)' == 'true'">HAVE_AMD64_ASM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/builds/msvc/vs2012/libsodium/libsodium.props
+++ b/builds/msvc/vs2012/libsodium/libsodium.props
@@ -25,7 +25,7 @@
       <EnablePREfast>false</EnablePREfast>
       <PreprocessorDefinitions>inline=__inline;NATIVE_LITTLE_ENDIAN;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'StaticLibrary'">SODIUM_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">SODIUM_DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-amd64asm)' == 'true'">HAVE_AMD64_ASM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/builds/msvc/vs2013/libsodium/libsodium.props
+++ b/builds/msvc/vs2013/libsodium/libsodium.props
@@ -25,7 +25,7 @@
       <EnablePREfast>false</EnablePREfast>
       <PreprocessorDefinitions>inline=__inline;NATIVE_LITTLE_ENDIAN;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'StaticLibrary'">SODIUM_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">SODIUM_DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-amd64asm)' == 'true'">HAVE_AMD64_ASM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/src/libsodium/include/sodium/export.h
+++ b/src/libsodium/include/sodium/export.h
@@ -13,7 +13,7 @@
 # define SODIUM_EXPORT
 #else
 # if defined(_MSC_VER)
-#  ifdef DLL_EXPORT
+#  ifdef SODIUM_DLL_EXPORT
 #   define SODIUM_EXPORT __declspec(dllexport)
 #  else
 #   define SODIUM_EXPORT __declspec(dllimport)


### PR DESCRIPTION
The purpose of this change is to use ZeroMQ's curve security using PyZMQ in Python 2.7 on Windows.

Since C extensions for Python 2.7 must be compiled with VS 2008, I need to be able to compile libsodium with Visual Studio 2008.  I understand that this compiler is quite old, but the number of changes to fix the VS 2008 build is quite small.  The changes are limited to:
1) working around the absence of `<stdint.h>`; and
2) VS 2008's confusion when both `static` and `inline` qualify a function.

In the process, I've also realized that both libzmq and libsodium use the same `DLL_EXPORT` macro to control visibility of symbols.  This makes it impossible to build libsodium as a dependency of libzmq on Windows when both are build as DLLs.  Since the name of the macro is arbitrary, I added a library prefix to prevent this conflict.

I also have a working VS 2008 solution to build libsodium on Windows.  However, I can't get it to output the build products under the correct `bin\` and `obj\` folder with a structure that matches those of the other solutions.  Since I couldn't get around this issue, I didn't include it in the pull request.  If you're interested anyways, let me know and I can add it.

Cheers!
