### PR TITLE
fix building visual studio projects within a path containing white space...

### DIFF
--- a/builds/msvc/vs2010/libsodium/libsodium.props
+++ b/builds/msvc/vs2010/libsodium/libsodium.props
@@ -17,7 +17,7 @@
   
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>copy $(BuildRoot)version.h $(RepoRoot)src\libsodium\include\sodium\</Command>
+      <Command>copy "$(BuildRoot)version.h" "$(RepoRoot)src\libsodium\include\sodium\"</Command>
     </PreBuildEvent>
     <ClCompile>
       <AdditionalIncludeDirectories>$(RepoRoot)src\libsodium\include;$(RepoRoot)src\libsodium\include\sodium\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/builds/msvc/vs2012/libsodium/libsodium.props
+++ b/builds/msvc/vs2012/libsodium/libsodium.props
@@ -17,7 +17,7 @@
   
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>copy $(BuildRoot)version.h $(RepoRoot)src\libsodium\include\sodium\</Command>
+      <Command>copy "$(BuildRoot)version.h" "$(RepoRoot)src\libsodium\include\sodium\"</Command>
     </PreBuildEvent>
     <ClCompile>
       <AdditionalIncludeDirectories>$(RepoRoot)src\libsodium\include;$(RepoRoot)src\libsodium\include\sodium\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/builds/msvc/vs2013/libsodium/libsodium.props
+++ b/builds/msvc/vs2013/libsodium/libsodium.props
@@ -17,7 +17,7 @@
   
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>copy $(BuildRoot)version.h $(RepoRoot)src\libsodium\include\sodium\</Command>
+      <Command>copy "$(BuildRoot)version.h" "$(RepoRoot)src\libsodium\include\sodium\"</Command>
     </PreBuildEvent>
     <ClCompile>
       <AdditionalIncludeDirectories>$(RepoRoot)src\libsodium\include;$(RepoRoot)src\libsodium\include\sodium\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/msvc-scripts/sodium.props
+++ b/msvc-scripts/sodium.props
@@ -12,13 +12,13 @@
       <PreprocessorDefinitions>inline=__inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <PreBuildEvent>
-      <Command>$(SolutionDir)/msvc-scripts/process.bat</Command>
+      <Command>"$(SolutionDir)/msvc-scripts/process.bat"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Process .in files</Message>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>$(SolutionDir)/test/default/wintest.bat $(Configuration) $(Platform)</Command>
+      <Command>"$(SolutionDir)/test/default/wintest.bat" $(Configuration) $(Platform)</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Run the test suite</Message>


### PR DESCRIPTION
...s

fix msbuild command path arguments containing white spaces
