### PR TITLE
change '-pie' to '-Wl,-pie' to squash clang warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -162,7 +162,7 @@ AS_IF([test "$enable_pie" != "no"],[
     AX_CHECK_LINK_FLAG([-fPIE],
       [AX_CHECK_LINK_FLAG([-pie],
         [CFLAGS="$CFLAGS -fPIE"
-         LDFLAGS="$LDFLAGS -pie"])
+         LDFLAGS="$LDFLAGS -Wl,-pie"])
     ])
   ])
 ])


### PR DESCRIPTION
When running `dist-build/ios.sh` on master I'm seeing a lot of the following:

```
clang: warning: argument unused during compilation: '-pie'
```

This appears to fix the issue for me, but I'm not sure if it'll break the build process for older/non-clang compilers. Any thoughts?
