### PR TITLE
Add '-Wl,-pie' check to squash clang warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -169,7 +169,6 @@ AS_IF([test "$enable_pie" != "no"],[
                 LDFLAGS="$LDFLAGS -pie"
             ])
         ])
-        AX_CHECK_LINK_FLAG([-pie], [])
     ])
   ])
 ])


### PR DESCRIPTION
Clang on OSX doesn't like the `-pie` linker flag, instead it's expecting `-Wl,-pie`. This adds a check for `-Wl,-pie` linker flag support and opts to use it when valid.
