### PR TITLE
[DO NOT MERGE} split crypto_sign_verify_detached

### DIFF
--- a/src/libsodium/crypto_sign/ed25519/ref10/open.c
+++ b/src/libsodium/crypto_sign/ed25519/ref10/open.c
@@ -10,29 +10,39 @@
 #include "utils.h"
 
 int
-crypto_sign_verify_detached(const unsigned char *sig, const unsigned char *m,
-                            unsigned long long mlen, const unsigned char *pk)
+crypto_sign_verify_beforenm(unsigned char *A, const unsigned char *pk)
 {
-    crypto_hash_sha512_state hs;
-    unsigned char h[64];
-    unsigned char rcheck[32];
-    unsigned int  i;
+    unsigned int i;
     unsigned char d = 0;
-    ge_p3 A;
-    ge_p2 R;
 
-    if (sig[63] & 224) {
-        return -1;
-    }
-    if (ge_frombytes_negate_vartime(&A, pk) != 0) {
-        return -1;
-    }
     for (i = 0; i < 32; ++i) {
         d |= pk[i];
     }
     if (d == 0) {
         return -1;
     }
+    if (ge_frombytes_negate_vartime((ge_p3 *)A, pk) != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int
+crypto_sign_verify_detached_afternm(const unsigned char *sig, const unsigned char *m,
+                                    unsigned long long mlen, const unsigned char *A,
+                                    const unsigned char *pk)
+{
+    crypto_hash_sha512_state hs;
+    unsigned char h[64];
+    unsigned char rcheck[32];
+    unsigned int  i;
+    ge_p2 R;
+
+    if (sig[63] & 224) {
+        return -1;
+    }
+
     crypto_hash_sha512_init(&hs);
     crypto_hash_sha512_update(&hs, sig, 32);
     crypto_hash_sha512_update(&hs, pk, 32);
@@ -40,11 +50,24 @@ crypto_sign_verify_detached(const unsigned char *sig, const unsigned char *m,
     crypto_hash_sha512_final(&hs, h);
     sc_reduce(h);
 
-    ge_double_scalarmult_vartime(&R, h, &A, sig + 32);
+    ge_double_scalarmult_vartime(&R, h, (ge_p3 *)A, sig + 32);
     ge_tobytes(rcheck, &R);
 
     return crypto_verify_32(rcheck, sig) | (-(rcheck == sig)) |
            sodium_memcmp(sig, rcheck, 32);
+}
+
+int
+crypto_sign_verify_detached(const unsigned char *sig, const unsigned char *m,
+                            unsigned long long mlen, const unsigned char *pk)
+{
+    ge_p3 A;
+
+    if (crypto_sign_verify_beforenm((unsigned char *)&A, pk)) {
+        return -1;
+    }
+
+    return crypto_sign_verify_detached_afternm(sig, m, mlen, (unsigned char *)&A, pk);
 }
 
 int


### PR DESCRIPTION
(This is a work in progress and needs to be completed provided the feedback is positive :))

The motivation is very simple: I checked how many public key signatures/verifications I can do on my machine and it turned out that it's almost three times more signatures than verifications.  I checked the SUPERCOP benchmarks and saw that the this is pretty much the case for all platforms listed there.

Then I looked at the code and noticed public key is converted to some internal representation every time a verification is performed.  Using crypto_box example, I split out this conversion in a separate function.  I did not do any benchmarking on my machine yet, as I wanted to hear what would be the opinion about this kind of change.

I believe the missing bits are:
- [ ] prototype in include file
- [ ] updated test suite (??)

(And, yes, I'd appreciate if somebody would tell what beforenm/afternm stand for :))