### PR TITLE
Add PIE build for Android 5.x support

### DIFF
--- a/dist-build/android5-armv7.sh
+++ b/dist-build/android5-armv7.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export CFLAGS="-Os -mfloat-abi=softfp -mfpu=vfpv3-d16 -mthumb -marm -march=armv7-a -fvisibility=default -fPIE"
+export LDFLAGS="-rdynamic -fPIE -pie"
+TARGET_ARCH=arm HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"


### PR DESCRIPTION
Android 5 requires that files support position independent executables otherwise the following error occurs:
error: only position independent executables (PIE) are supported.
Add PIE flags to CFLAGS and LDFLAGS