### PR TITLE
Update NuGet configuration for version 1.0.3

### DIFF
--- a/packaging/nuget/package.config
+++ b/packaging/nuget/package.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- These values are populated into the package.gsl templates by package.bat. -->
 <!-- The target attribute controls path and file name only, id controls package naming. -->
-<package id="libsodium_vc120" target="libsodium" version = "1.0.0.0" pathversion="1_0_0_0" platformtoolset="v120" />
+<package id="libsodium_vc120" target="libsodium" version = "1.0.3.0" pathversion="1_0_3_0" platformtoolset="v120" />


### PR DESCRIPTION
`package.nuspec`, `package.targets`, and `package.xml` are generated from this config file, so I didn't update them (thus it may be reasonable to remove them from the repository)