### PR TITLE
Add simple PKI certificate format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ test/default/box_easy
 test/default/box_easy2
 test/default/box_seal
 test/default/box_seed
+test/default/cert
 test/default/chacha20
 test/default/core1
 test/default/core2

--- a/src/libsodium/Makefile.am
+++ b/src/libsodium/Makefile.am
@@ -25,6 +25,7 @@ libsodium_la_SOURCES = \
 	crypto_box/curve25519xsalsa20poly1305/ref/before_curve25519xsalsa20poly1305.c \
 	crypto_box/curve25519xsalsa20poly1305/ref/box_curve25519xsalsa20poly1305.c \
 	crypto_box/curve25519xsalsa20poly1305/ref/keypair_curve25519xsalsa20poly1305.c \
+	crypto_cert/crypto_cert.c \
 	crypto_core/hsalsa20/ref2/core_hsalsa20.c \
 	crypto_core/hsalsa20/core_hsalsa20_api.c \
 	crypto_core/hsalsa20/ref2/api.h \

--- a/src/libsodium/crypto_cert/crypto_cert.c
+++ b/src/libsodium/crypto_cert/crypto_cert.c
@@ -1,0 +1,146 @@
+
+#include "crypto_cert.h"
+
+#define crypto_cert_HEADER_BYTES (sizeof(uint8_t) /*version*/ \
+                                 +sizeof(uint8_t) /*flags*/ \
+                                 +sizeof(uint32_t) /*valid from*/ \
+                                 +sizeof(uint32_t) /*valid until*/ \
+)
+
+static int
+crypto_cert_swapl(uint32_t n)
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+    unsigned char *np = (unsigned char*)&n;
+    return
+        ((uint32_t)np[0] << 24) |
+        ((uint32_t)np[1] << 16) |
+        ((uint32_t)np[2] << 8) |
+        (uint32_t)np[3];
+#endif
+    return n;
+}
+
+int
+crypto_cert(unsigned char *out, uint8_t flags, time_t valid_from,
+            time_t valid_until, const unsigned char *ad,
+            unsigned long long adlen, const unsigned char *pk,
+            const unsigned char *s, const unsigned char *k)
+{
+    //build cert
+    unsigned char *pos = out;
+    const uint8_t version = crypto_cert_VERSION;
+
+    memcpy(pos, &version, sizeof(version));
+    pos += sizeof(version);
+
+    memcpy(pos, &flags, sizeof(flags));
+    pos += sizeof(flags);
+
+    const uint32_t from = crypto_cert_swapl((uint32_t)valid_from);
+    memcpy(pos, &from, sizeof(from));
+    pos += sizeof(from);
+
+    const uint32_t until = crypto_cert_swapl((uint32_t)valid_until);
+    memcpy(pos, &until, sizeof(until));
+    pos += sizeof(until);
+
+    memcpy(pos, pk, crypto_sign_PUBLICKEYBYTES);
+    pos += crypto_sign_PUBLICKEYBYTES;
+
+    memcpy(pos, s, crypto_sign_PUBLICKEYBYTES);
+    pos += crypto_sign_PUBLICKEYBYTES;
+
+    //hash cert & additional data
+    unsigned char hash[crypto_generichash_BYTES];
+    crypto_generichash_state state;
+    crypto_generichash_init(&state, NULL, 0, sizeof(hash));
+    crypto_generichash_update(&state, out, pos - out);
+    crypto_generichash_update(&state, ad, adlen);
+    crypto_generichash_final(&state, hash, sizeof(hash));
+
+    //sign hash & append signature to cert
+    crypto_sign_detached(pos, NULL, hash, sizeof(hash), k);
+    return crypto_sign_verify_detached(pos, hash, sizeof(hash), s);
+}
+
+int
+crypto_cert_verify(const unsigned char *c, const unsigned char *ad,
+                   unsigned long long adlen)
+{
+    //verify version
+    if(crypto_cert_version(c) != crypto_cert_VERSION)
+        return -1;
+
+    //verify validity period
+    time_t now = time(NULL);
+    if(crypto_cert_valid_from(c) > now || crypto_cert_valid_until(c) < now)
+    {
+        return -1;
+    }
+
+    //hash cert & additional data
+    unsigned char hash[crypto_generichash_BYTES];
+    crypto_generichash_state state;
+    crypto_generichash_init(&state, NULL, 0, sizeof(hash));
+    crypto_generichash_update(&state, c, crypto_cert_BYTES -
+        crypto_sign_BYTES);
+    crypto_generichash_update(&state, ad, adlen);
+    crypto_generichash_final(&state, hash, sizeof(hash));
+
+    //verify signature
+    unsigned char s[crypto_sign_PUBLICKEYBYTES];
+    crypto_cert_signer(s, c);
+    return crypto_sign_verify_detached(c + crypto_cert_BYTES -
+        crypto_sign_BYTES, hash, sizeof(hash), s);
+}
+
+void
+crypto_cert_pk(unsigned char *out, const unsigned char *c)
+{
+    memcpy(out, c + crypto_cert_HEADER_BYTES, crypto_sign_PUBLICKEYBYTES);
+}
+
+void
+crypto_cert_signer(unsigned char *out, const unsigned char *c)
+{
+    memcpy(out, c + crypto_cert_HEADER_BYTES + crypto_sign_PUBLICKEYBYTES,
+        crypto_sign_PUBLICKEYBYTES);
+}
+
+void
+crypto_cert_signature(unsigned char *out, const unsigned char *c)
+{
+    memcpy(out, c + crypto_cert_HEADER_BYTES + crypto_sign_PUBLICKEYBYTES * 2,
+        crypto_sign_BYTES);
+}
+
+time_t
+crypto_cert_valid_from(const unsigned char *c)
+{
+    uint32_t from;
+    c += sizeof(uint8_t) /*version*/ + sizeof(uint8_t) /*flags*/;
+    memcpy(&from, c, sizeof(from));
+    return crypto_cert_swapl(from);
+}
+
+time_t
+crypto_cert_valid_until(const unsigned char *c)
+{
+    uint32_t until;
+    c += sizeof(uint8_t) /*version*/ + sizeof(uint8_t) /*flags*/
+        + sizeof(uint32_t) /*from*/;
+    memcpy(&until, c, sizeof(until));
+    return crypto_cert_swapl(until);
+}
+
+uint8_t
+crypto_cert_version(const unsigned char *c)
+{
+    return (uint8_t)c[0];
+}
+
+uint8_t
+crypto_cert_flags(const unsigned char *c) {
+    return (uint8_t)c[1];
+}

--- a/src/libsodium/crypto_cert/crypto_cert.c
+++ b/src/libsodium/crypto_cert/crypto_cert.c
@@ -75,9 +75,7 @@ crypto_cert_verify(const unsigned char *c, const unsigned char *ad,
     //verify validity period
     time_t now = time(NULL);
     if(crypto_cert_valid_from(c) > now || crypto_cert_valid_until(c) < now)
-    {
         return -1;
-    }
 
     //hash cert & additional data
     unsigned char hash[crypto_generichash_BYTES];

--- a/src/libsodium/include/Makefile.am
+++ b/src/libsodium/include/Makefile.am
@@ -9,6 +9,7 @@ SODIUM_EXPORT = \
 	sodium/crypto_auth_hmacsha512256.h \
 	sodium/crypto_box.h \
 	sodium/crypto_box_curve25519xsalsa20poly1305.h \
+	sodium/crypto_cert.h \
 	sodium/crypto_core_hsalsa20.h \
 	sodium/crypto_core_salsa20.h \
 	sodium/crypto_core_salsa2012.h \

--- a/src/libsodium/include/sodium.h
+++ b/src/libsodium/include/sodium.h
@@ -10,6 +10,7 @@
 #include "sodium/crypto_auth_hmacsha512256.h"
 #include "sodium/crypto_box.h"
 #include "sodium/crypto_box_curve25519xsalsa20poly1305.h"
+#include "sodium/crypto_cert.h"
 #include "sodium/crypto_core_hsalsa20.h"
 #include "sodium/crypto_core_salsa20.h"
 #include "sodium/crypto_core_salsa2012.h"

--- a/src/libsodium/include/sodium/crypto_cert.h
+++ b/src/libsodium/include/sodium/crypto_cert.h
@@ -1,0 +1,59 @@
+#ifndef crypto_cert_H
+#define crypto_cert_H
+
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+#include "crypto_sign.h"
+#include "crypto_generichash.h"
+#include "export.h"
+
+#define crypto_cert_VERSION 1
+
+#define crypto_cert_BYTES (sizeof(uint8_t) /*version*/ \
+                          +sizeof(uint8_t) /*flags*/ \
+                          +sizeof(uint32_t) /*valid from*/ \
+                          +sizeof(uint32_t) /*valid until*/ \
+                          +crypto_sign_PUBLICKEYBYTES /*pk*/ \
+                          +crypto_sign_PUBLICKEYBYTES /*signer*/ \
+                          +crypto_sign_BYTES /*signature*/ \
+                          )
+
+SODIUM_EXPORT
+int crypto_cert(unsigned char *out,
+                uint8_t flags,
+                time_t valid_from,
+                time_t valid_until,
+                const unsigned char *ad,
+                unsigned long long adlen,
+                const unsigned char *pk,
+                const unsigned char *s,
+                const unsigned char *k);
+
+SODIUM_EXPORT
+int crypto_cert_verify(const unsigned char *c, const unsigned char *ad,
+                       unsigned long long adlen);
+
+SODIUM_EXPORT
+void crypto_cert_pk(unsigned char *out, const unsigned char *c);
+
+SODIUM_EXPORT
+void crypto_cert_signer(unsigned char *out, const unsigned char *c);
+
+SODIUM_EXPORT
+void crypto_cert_signature(unsigned char *out, const unsigned char *c);
+
+SODIUM_EXPORT
+time_t crypto_cert_valid_from(const unsigned char *c);
+
+SODIUM_EXPORT
+time_t crypto_cert_valid_until(const unsigned char *c);
+
+SODIUM_EXPORT
+uint8_t crypto_cert_version(const unsigned char *c);
+
+SODIUM_EXPORT
+uint8_t crypto_cert_flags(const unsigned char *c);
+
+#endif

--- a/test/default/Makefile.am
+++ b/test/default/Makefile.am
@@ -19,6 +19,7 @@ EXTRA_DIST = \
 	box_seal.exp \
 	box_seed.exp \
 	chacha20.exp \
+	cert.exp \
 	core1.exp \
 	core2.exp \
 	core3.exp \
@@ -79,6 +80,7 @@ DISTCLEANFILES = \
 	box_seal.res \
 	box_seed.res \
 	chacha20.res \
+	cert.res \
 	core1.res \
 	core2.res \
 	core3.res \
@@ -149,6 +151,7 @@ TESTS_TARGETS = \
 	box_seal \
 	box_seed \
 	chacha20 \
+	cert \
 	core1 \
 	core2 \
 	core3 \
@@ -249,6 +252,9 @@ box_seed_LDADD            = $(TESTS_LDADD)
 
 chacha20_SOURCE           = cmptest.h chacha20.c
 chacha20_LDADD            = $(TESTS_LDADD)
+
+cert_SOURCE               = cmptest.h cert.c
+cert_LDADD                = $(TESTS_LDADD)
 
 core1_SOURCE              = cmptest.h core1.c
 core1_LDADD               = $(TESTS_LDADD)

--- a/test/default/cert.c
+++ b/test/default/cert.c
@@ -1,0 +1,40 @@
+
+#define TEST_NAME "cert"
+#include "cmptest.h"
+
+int
+main(void)
+{
+  unsigned char pk[crypto_sign_PUBLICKEYBYTES];
+  unsigned char sk[crypto_sign_SECRETKEYBYTES];
+  unsigned char c[crypto_cert_BYTES];
+  const char *ad = "Blue fish eat red food, but only on Sundays.";
+  const char *ad_bad = "Blue fish eat red food, but only on Fridays.";
+  crypto_sign_keypair(pk, sk);
+
+  //create & verify
+  if(crypto_cert(c, 0, 0, time(NULL) + 60, NULL, 0, pk, pk, sk))
+    printf("crypto_cert() failed\n");
+  if(crypto_cert_verify(c, NULL, 0))
+    printf("crypto_cert_verify() failed\n");
+  c[0] = 0;
+  if(!crypto_cert_verify(c, NULL, 0))
+    printf("Cert is invalid, but crypto_cert_verify() passed it anyway\n");
+
+  //validity period
+  assert(!crypto_cert(c, 0, time(NULL) + 60, time(NULL) + 120, NULL, 0, pk, pk, sk));
+  if(!crypto_cert_verify(c, NULL, 0))
+    printf("Cert is not yet valid, but crypto_cert_verify() passed it anyway\n");
+  assert(!crypto_cert(c, 0, 0, time(NULL) - 120, NULL, 0, pk, pk, sk));
+  if(!crypto_cert_verify(c, NULL, 0))
+    printf("Cert has expired, but crypto_cert_verify() passed it anyway\n");
+
+  //additional data
+  assert(!crypto_cert(c, 0, 0, time(NULL) + 60, ad, strlen(ad) + 1, pk, pk, sk));
+  if(crypto_cert_verify(c, ad, strlen(ad) + 1))
+    printf("crypto_cert_verify() failed with additional data\n");
+  if(!crypto_cert_verify(c, ad_bad, strlen(ad_bad) + 1))
+    printf("Additional data is invalid, but crypto_cert_verify() passed it anyway\n");
+
+  return 0;
+}

--- a/test/default/cert.c
+++ b/test/default/cert.c
@@ -30,10 +30,11 @@ main(void)
     printf("Cert has expired, but crypto_cert_verify() passed it anyway\n");
 
   //additional data
-  assert(!crypto_cert(c, 0, 0, time(NULL) + 60, ad, strlen(ad) + 1, pk, pk, sk));
-  if(crypto_cert_verify(c, ad, strlen(ad) + 1))
+  assert(!crypto_cert(c, 0, 0, time(NULL) + 60, (const unsigned char*)ad,
+      strlen(ad) + 1, pk, pk, sk));
+  if(crypto_cert_verify(c, (const unsigned char*)ad, strlen(ad) + 1))
     printf("crypto_cert_verify() failed with additional data\n");
-  if(!crypto_cert_verify(c, ad_bad, strlen(ad_bad) + 1))
+  if(!crypto_cert_verify(c, (const unsigned char*)ad_bad, strlen(ad_bad) + 1))
     printf("Additional data is invalid, but crypto_cert_verify() passed it anyway\n");
 
   return 0;


### PR DESCRIPTION
Simple PKI certificate container, bundling from / until validity
timestamps, certificate pk, signer pk, &signature. Allows for
arbitrary additional data to also be attached to the cert and signed /
verified along with it.

Also includes a version number and an 8-bit 'flags' field to allow
room for future revision without breaking backwards compatibility.

Unsure whether this is something you want in libsodium, but it's certainly something I would find extremely useful. If it's something you're open to including, I'm intending to build a 'secure channel' feature on top of it.

If you'd prefer not to merge this kind of thing, then no worries - I just want to check before I sink too much time into developing stuff on top of it.