### PR TITLE
If browser `crypto` is not available, try `msCrypto` before assuming a Node environment.

### DIFF
--- a/src/libsodium/randombytes/randombytes.c
+++ b/src/libsodium/randombytes/randombytes.c
@@ -60,7 +60,8 @@ randombytes_stir(void)
     EM_ASM({
         if (Module.getRandomValue === undefined) {
             try {
-                var crypto_ = ("object" === typeof window ? window : self).crypto,
+                var window_ = "object" === typeof window ? window : self,
+                    crypto_ = typeof window_.crypto !== "undefined" ? window_.crypto : window_.msCrypto,
                     randomValuesStandard = function() {
                         var buf = new Uint32Array(1);
                         crypto_.getRandomValues(buf);


### PR DESCRIPTION
`window.msCrypto` is available in IE11[[1](https://msdn.microsoft.com/library/dn265046(v=vs.85).aspx)] and provides `getRandomValues`. I've built libsodium.js against this and everything is green.