### PR TITLE
Add crypt_generichash_blake2b_statebytes function

### DIFF
--- a/src/libsodium/crypto_generichash/blake2/generichash_blake2_api.c
+++ b/src/libsodium/crypto_generichash/blake2/generichash_blake2_api.c
@@ -39,3 +39,10 @@ size_t
 crypto_generichash_blake2b_personalbytes(void) {
     return crypto_generichash_blake2b_PERSONALBYTES;
 }
+
+size_t
+crypto_generichash_blake2b_statebytes(void)
+{
+    return (sizeof(crypto_generichash_blake2b_state) + (size_t) 63U)
+        & ~(size_t) 63U;
+}

--- a/src/libsodium/include/sodium/crypto_generichash_blake2b.h
+++ b/src/libsodium/include/sodium/crypto_generichash_blake2b.h
@@ -68,6 +68,9 @@ SODIUM_EXPORT
 size_t crypto_generichash_blake2b_personalbytes(void);
 
 SODIUM_EXPORT
+size_t crypto_generichash_blake2b_statebytes(void);
+
+SODIUM_EXPORT
 int crypto_generichash_blake2b(unsigned char *out, size_t outlen,
                                const unsigned char *in,
                                unsigned long long inlen,

--- a/test/default/generichash3.c
+++ b/test/default/generichash3.c
@@ -20,6 +20,7 @@ main(void)
     size_t        i;
     size_t        j;
 
+    assert(crypto_generichash_blake2b_statebytes() >= sizeof st);
     for (h = 0; h < crypto_generichash_blake2b_KEYBYTES_MAX; ++h) {
         k[h] = (unsigned char) h;
     }


### PR DESCRIPTION
The function crypto_generichash_statebytes exists to dynamically determine the
size of a crypto_generichash_state struct. This is useful when using libsodium
from a language which can't use sizeof on C types. However, no equivalent
existed for the crypto_generichash_blake2b_state struct for users who want to
explicitly use the blake2b algorithm.

The function crypt_generichash_blake2b_statebytes is added to fill this gap.