### PR TITLE
Fix up relative includes of sodium/common.h

### DIFF
--- a/src/libsodium/crypto_aead/chacha20poly1305/sodium/aead_chacha20poly1305.c
+++ b/src/libsodium/crypto_aead/chacha20poly1305/sodium/aead_chacha20poly1305.c
@@ -10,7 +10,7 @@
 #include "crypto_verify_16.h"
 #include "utils.h"
 
-#include "../../sodium/common.h"
+#include "../../../sodium/common.h"
 
 static const unsigned char _pad0[16] = { 0 };
 

--- a/src/libsodium/crypto_core/hsalsa20/ref2/core_hsalsa20.c
+++ b/src/libsodium/crypto_core/hsalsa20/ref2/core_hsalsa20.c
@@ -8,7 +8,7 @@ Public domain.
 #include <stdlib.h>
 
 #include "crypto_core_hsalsa20.h"
-#include "../../sodium/common.h"
+#include "../../../sodium/common.h"
 
 #define ROUNDS 20
 #define U32C(v) (v##U)

--- a/src/libsodium/crypto_core/salsa20/ref/core_salsa20.c
+++ b/src/libsodium/crypto_core/salsa20/ref/core_salsa20.c
@@ -8,7 +8,7 @@ Public domain.
 #include <stdlib.h>
 
 #include "crypto_core_salsa20.h"
-#include "../../sodium/common.h"
+#include "../../../sodium/common.h"
 
 #define ROUNDS 20
 #define U32C(v) (v##U)

--- a/src/libsodium/crypto_core/salsa2012/ref/core_salsa2012.c
+++ b/src/libsodium/crypto_core/salsa2012/ref/core_salsa2012.c
@@ -8,7 +8,7 @@ Public domain.
 #include <stdlib.h>
 
 #include "crypto_core_salsa2012.h"
-#include "../../sodium/common.h"
+#include "../../../sodium/common.h"
 
 #define ROUNDS 12
 #define U32C(v) (v##U)

--- a/src/libsodium/crypto_core/salsa208/ref/core_salsa208.c
+++ b/src/libsodium/crypto_core/salsa208/ref/core_salsa208.c
@@ -8,7 +8,7 @@ Public domain.
 #include <stdlib.h>
 
 #include "crypto_core_salsa208.h"
-#include "../../sodium/common.h"
+#include "../../../sodium/common.h"
 
 #define ROUNDS 8
 #define U32C(v) (v##U)

--- a/src/libsodium/crypto_generichash/blake2/ref/blake2b-compress-ref.c
+++ b/src/libsodium/crypto_generichash/blake2/ref/blake2b-compress-ref.c
@@ -4,7 +4,7 @@
 
 #include "blake2.h"
 #include "blake2-impl.h"
-#include "../../sodium/common.h"
+#include "../../../sodium/common.h"
 
 CRYPTO_ALIGN(64) static const uint64_t blake2b_IV[8] =
 {

--- a/src/libsodium/crypto_shorthash/siphash24/ref/shorthash_siphash24.c
+++ b/src/libsodium/crypto_shorthash/siphash24/ref/shorthash_siphash24.c
@@ -1,5 +1,5 @@
 #include "crypto_shorthash_siphash24.h"
-#include "../../sodium/common.h"
+#include "../../../sodium/common.h"
 
 typedef uint64_t u64;
 typedef uint32_t u32;

--- a/src/libsodium/crypto_stream/aes128ctr/portable/common.h
+++ b/src/libsodium/crypto_stream/aes128ctr/portable/common.h
@@ -5,7 +5,7 @@
 #define COMMON_H
 
 #include "types.h"
-#include "../../sodium/common.h"
+#include "../../../sodium/common.h"
 
 /* Macros required only for key expansion */
 

--- a/src/libsodium/crypto_stream/chacha20/ref/stream_chacha20_ref.c
+++ b/src/libsodium/crypto_stream/chacha20/ref/stream_chacha20_ref.c
@@ -13,7 +13,7 @@
 #include "crypto_stream_chacha20.h"
 #include "stream_chacha20_ref.h"
 #include "../stream_chacha20.h"
-#include "../../sodium/common.h"
+#include "../../../sodium/common.h"
 
 struct chacha_ctx {
     uint32_t input[16];


### PR DESCRIPTION
These includes look like they are intended to be resolved relative to their containing files. Currently, however, they successfully resolve only because the compiler gets the flag `-I./include/sodium` and appending these paths onto `./include/sodium` just happens to do the right thing.