### PR TITLE
Stable branch for Android 64

### DIFF
--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -24,7 +24,7 @@ export PATH="${PATH}:${TOOLCHAIN_DIR}/bin"
 
 rm -rf "${TOOLCHAIN_DIR}" "${PREFIX}"
 
-bash $MAKE_TOOLCHAIN --platform="${NDK_PLATFORM:-android-16}" \
+bash $MAKE_TOOLCHAIN --platform="${NDK_PLATFORM:-android-24}" \
     --arch="$ARCH" --install-dir="$TOOLCHAIN_DIR" && \
 ./configure \
     --disable-soname-versions \


### PR DESCRIPTION
Simply changing the platform to 24 seems to do the job for all Android based architectures.
Tested with Android devices and emulators down to Version 16