### PR TITLE
fix avx2 feature detection, fixes #395

### DIFF
--- a/src/libsodium/sodium/runtime.c
+++ b/src/libsodium/sodium/runtime.c
@@ -168,7 +168,9 @@ _sodium_runtime_intel_cpu_features(CPUFeatures * const cpu_features)
 #if defined(HAVE_AVX2INTRIN_H) || \
     (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64) || defined(_M_IX86)))
     if (cpu_features->has_avx) {
-        cpu_features->has_avx2 = ((cpu_info[1] & CPUID_EBX_AVX2) != 0x0);
+        unsigned int cpu_info7[4];
+        _cpuid(cpu_info7, 0x00000007);
+        cpu_features->has_avx2 = ((cpu_info7[1] & CPUID_EBX_AVX2) != 0x0);
     }
 #endif
 


### PR DESCRIPTION
cpuid needed to get called with EAX = 7 to get the "extended features"
(not with EAX = 1 for the "features").

I did run `make check`, everything passed.

Before change:
```
sodium_runtime_has_avx: 1
sodium_runtime_has_avx2: 0
Iterations: 250000
Testing with block size: 65536  30009249 usec (  4367 Mb/s)
```

After change:
```
sodium_runtime_has_avx: 1
sodium_runtime_has_avx2: 1
Iterations: 250000
Testing with block size: 65536  22358079 usec (  5862 Mb/s)
```
