### PR TITLE
Support madvise() on FreeBSD

### DIFF
--- a/src/libsodium/sodium/utils.c
+++ b/src/libsodium/sodium/utils.c
@@ -50,6 +50,13 @@
 #if defined(HAVE_ALIGNED_MALLOC) && (defined(WINAPI_DESKTOP) || defined(HAVE_MPROTECT))
 # define HAVE_PAGE_PROTECTION
 #endif
+/* FreeBSD defines these with its own names */
+if !defined(MADV_DONTDUMP) && defined(HAVE_MADVISE)
+# define MADV_DONTDUMP  MADV_NOCORE
+#endif
+if !defined(MADV_DODUMP) && defined(HAVE_MADVISE)
+# define MADV_DODUMP  MADV_CORE
+#endif
 
 static size_t page_size;
 static unsigned char canary[CANARY_SIZE];


### PR DESCRIPTION
FreeBSD have madvise() behaviors equivalent to MADV_DONTDUMP and MADV_DODUMP but with its own names.
Add definitions for these behaviors used in sodium_mlock() and sodium_munlock() if FreeBSD names are found and Linux ones don't.