### PR TITLE
Move copied-and-pasted code into a single header file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@
 *.status
 *.tar.*
 *~
+.#*
+#*#
 .DS_Store
 .deps
 .dirstamp

--- a/src/libsodium/randombytes/linux-block-on-random.h
+++ b/src/libsodium/randombytes/linux-block-on-random.h
@@ -1,0 +1,27 @@
+# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM)
+# include <poll.h>
+static int
+randombytes_block_on_dev_random(void)
+{
+    struct pollfd pfd;
+    int           fd;
+    int           pret;
+
+    fd = open("/dev/random", O_RDONLY);
+    if (fd == -1) {
+        return 0;
+    }
+    pfd.fd = fd;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    do {
+        pret = poll(&pfd, 1, -1);
+    } while (pret < 0 && (errno == EINTR || errno == EAGAIN));
+    if (pret != 1) {
+        (void) close(fd);
+        errno = EIO;
+        return -1;
+    }
+    return close(fd);
+}
+# endif

--- a/src/libsodium/randombytes/salsa20/randombytes_salsa20_random.c
+++ b/src/libsodium/randombytes/salsa20/randombytes_salsa20_random.c
@@ -7,7 +7,6 @@
 #endif
 #ifdef __linux__
 # include <sys/syscall.h>
-# include <poll.h>
 #endif
 
 #include <assert.h>
@@ -129,32 +128,7 @@ safe_read(const int fd, void * const buf_, size_t size)
 #endif
 
 #ifndef _WIN32
-# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM)
-static int
-randombytes_block_on_dev_random(void)
-{
-    struct pollfd pfd;
-    int           fd;
-    int           pret;
-
-    fd = open("/dev/random", O_RDONLY);
-    if (fd == -1) {
-        return 0;
-    }
-    pfd.fd = fd;
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-    do {
-        pret = poll(&pfd, 1, -1);
-    } while (pret < 0 && (errno == EINTR || errno == EAGAIN));
-    if (pret != 1) {
-        (void) close(fd);
-        errno = EIO;
-        return -1;
-    }
-    return close(fd);
-}
-# endif
+# include "../linux-block-on-random.h"
 
 # ifndef HAVE_SAFE_ARC4RANDOM
 static int

--- a/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c
+++ b/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c
@@ -7,7 +7,6 @@
 #endif
 #ifdef __linux__
 # include <sys/syscall.h>
-# include <poll.h>
 #endif
 
 #include <assert.h>
@@ -108,33 +107,7 @@ safe_read(const int fd, void * const buf_, size_t size)
 #endif
 
 #ifndef _WIN32
-# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM)
-static int
-randombytes_block_on_dev_random(void)
-{
-    struct pollfd pfd;
-    int           fd;
-    int           pret;
-
-    fd = open("/dev/random", O_RDONLY);
-    if (fd == -1) {
-        return 0;
-    }
-    pfd.fd = fd;
-    pfd.events = POLLIN;
-    pfd.revents = 0;
-    do {
-        pret = poll(&pfd, 1, -1);
-    } while (pret < 0 && (errno == EINTR || errno == EAGAIN));
-    if (pret != 1) {
-        (void) close(fd);
-        errno = EIO;
-        return -1;
-    }
-    return close(fd);
-}
-# endif
-
+#include "../linux-block-on-random.h"
 static int
 randombytes_sysrandom_random_dev_open(void)
 {


### PR DESCRIPTION
The code that blocks on `/dev/random` on Linux to ensure that
`/dev/urandom` is properly seeded was duplicated in
src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c and in
src/libsodium/randombytes/salsa20/randombytes_salsa20_random.c.  Move it
into a single header file.

Also, update .gitignore to ignore Emacs temporary files.