### PR TITLE
document why RtlGenRandom is used

### DIFF
--- a/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c
+++ b/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c
@@ -25,6 +25,12 @@
 #include "utils.h"
 
 #ifdef _WIN32
+/* `RtlGenRandom` is used over `CryptGenRandom` on Microsoft Windows based systems:
+ *  - `CryptGenRandom` requires pulling in `CryptoAPI` which causes unnecessary
+ *     memory overhead if no other Cryptography functionally is required.
+ *  - `RtlGenRandom` is thus called directly instead. A detailed explaination
+ *     can be found here: https://blogs.msdn.microsoft.com/michael_howard/2005/01/14/cryptographically-secure-random-number-on-windows-without-using-cryptoapi/
+ */
 # include <windows.h>
 # define RtlGenRandom SystemFunction036
 # if defined(__cplusplus)


### PR DESCRIPTION
I took me a while to figure out why `libsodium` uses `RtlGenRandom` over the `CryptGenRandom` functionality on Windows systems. I think this should be properly documented.