### PR TITLE
Fix x64 builds for MSVC < vc11

### DIFF
--- a/src/libsodium/crypto_generichash/blake2/ref/blake2b-compress-avx2.c
+++ b/src/libsodium/crypto_generichash/blake2/ref/blake2b-compress-avx2.c
@@ -7,7 +7,7 @@
 #include <string.h>
 
 #if (defined(HAVE_AVX2INTRIN_H) && defined(HAVE_EMMINTRIN_H) && defined(HAVE_TMMINTRIN_H) && defined(HAVE_SMMINTRIN_H)) || \
-    (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)))
+    (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)) && _MSC_VER > 1600)
 
 #pragma GCC target("sse2")
 #pragma GCC target("ssse3")

--- a/src/libsodium/crypto_generichash/blake2/ref/blake2b-ref.c
+++ b/src/libsodium/crypto_generichash/blake2/ref/blake2b-ref.c
@@ -429,7 +429,7 @@ blake2b_pick_best_implementation(void)
 {
 /* LCOV_EXCL_START */
 #if (defined(HAVE_AVX2INTRIN_H) && defined(HAVE_TMMINTRIN_H) && defined(HAVE_SMMINTRIN_H)) || \
-    (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)))
+    (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)) && _MSC_VER > 1600)
   if (sodium_runtime_has_avx2()) {
     blake2b_compress = blake2b_compress_avx2;
     return 0;


### PR DESCRIPTION
@jedisct1 x64 builds for VC9 and VC10 are broken now. I used this patch to create x64 builds for PHP 5.3 and PHP 5.4 (which some people are actually using):
https://www.apachelounge.com/viewtopic.php?t=6359