### PR TITLE
Better AVX2 detection for GCC compilers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -398,10 +398,15 @@ AS_IF([test "x$EMSCRIPTEN" = "x" -a "$host_os" != "pnacl"], [
 #endif
 #pragma GCC target("avx2")
 #include <immintrin.h>
-]], [[ __m256i x = _mm256_abs_epi8(_mm256_setzero_si256()); ]])],
+]], [[
+__m256i x = _mm256_abs_epi8(_mm256_setzero_si256());
+#ifdef __GNUC__
+__asm__ __volatile__ ("vpermq $1,%ymm1,%ymm2");
+#endif
+]])],
     [AC_MSG_RESULT(yes)
      AC_DEFINE([HAVE_AVX2INTRIN_H], [1], [AVX2 is available])
-     AX_CHECK_COMPILE_FLAG([-mavx2], [CFLAGS_AVX="-mavx2"])
+     AX_CHECK_COMPILE_FLAG([-mavx2], [CFLAGS_AVX2="-mavx2"])
      AC_MSG_CHECKING(if _mm256_broadcastsi128_si256 is correctly defined)
      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #ifdef __native_client__


### PR DESCRIPTION
I had a problem building libsodium 1.0.11 on gcc 4.8.1. The issue was with the AVX2 implementation of BLAKE2b - it looked like the configure script decided that AVX2 was supported by the compiler, but then compilation failed with a bunch of errors that looked like this:

  ...
  {standard input}:391: Error: operand type mismatch for `vpxor'
  {standard input}:398: Error: no such instruction: `vpermq $147,%ymm10,%ymm10'
  {standard input}:404: Error: no such instruction: `vpermq $78,%ymm9,%ymm9'
  {standard input}:411: Error: operand type mismatch for `vpaddq'
  {standard input}:418: Error: operand type mismatch for `vpsrlq'
  ...

I simply added one of the unknown instructions to the program used to detect AVX2 support, inside a `#ifdef __GNUC__` block. This fixed the issue.