### PR TITLE
Better AVX2 detection, try 2 (only using intrinsic functions)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -398,13 +398,12 @@ AS_IF([test "x$EMSCRIPTEN" = "x" -a "$host_os" != "pnacl"], [
 #endif
 #pragma GCC target("avx2")
 #include <immintrin.h>
-#include <string.h>
 ]], [[
 // the code below is intentionally crafted to make sure the compiler
 // can't optimize the AVX2 instructions away.
-__m256i x = _mm256_set1_epi32(0xdeadbeef);
-__m256i y = _mm256_permutevar8x32_epi32(x,x);
-return memcmp(&x, &y, sizeof(x)) != 0;
+__m256 x = _mm256_set1_ps(3.14);
+__m256 y = _mm256_permutevar8x32_ps(x, _mm256_set1_epi32(42));
+return _mm256_movemask_ps(_mm256_cmp_ps(x, y, _CMP_NEQ_OQ));
 ]])],
     [AC_MSG_RESULT(yes)
      AC_DEFINE([HAVE_AVX2INTRIN_H], [1], [AVX2 is available])

--- a/configure.ac
+++ b/configure.ac
@@ -398,7 +398,14 @@ AS_IF([test "x$EMSCRIPTEN" = "x" -a "$host_os" != "pnacl"], [
 #endif
 #pragma GCC target("avx2")
 #include <immintrin.h>
-]], [[ __m256i x = _mm256_abs_epi8(_mm256_setzero_si256()); ]])],
+#include <string.h>
+]], [[
+// the code below is intentionally crafted to make sure the compiler
+// can't optimize the AVX2 instructions away.
+__m256i x = _mm256_set1_epi32(0xdeadbeef);
+__m256i y = _mm256_permutevar8x32_epi32(x,x);
+return memcmp(&x, &y, sizeof(x)) != 0;
+]])],
     [AC_MSG_RESULT(yes)
      AC_DEFINE([HAVE_AVX2INTRIN_H], [1], [AVX2 is available])
      AX_CHECK_COMPILE_FLAG([-mavx2], [CFLAGS_AVX2="-mavx2"])


### PR DESCRIPTION
Here's a second attempt at better AVX2 detection. I dug pretty deeply into the generated assembly, and found that the old version (`__m256i x = _mm256_abs_epi8(_mm256_setzero_si256());`) generated ASM that didn't actually have any AVX2 instructions in it - they were optimized away completely (though I think there were some AVX1 instructions left over). So in cases where the compiler version was recent enough to support AVX2 but the assembler was too old and didn't support it, the configure script would fail to detect the problem.