### PR TITLE
add preprocessor flag to skip blocking /dev/random during libsodium init

### DIFF
--- a/src/libsodium/randombytes/salsa20/randombytes_salsa20_random.c
+++ b/src/libsodium/randombytes/salsa20/randombytes_salsa20_random.c
@@ -130,7 +130,7 @@ safe_read(const int fd, void * const buf_, size_t size)
 #endif
 
 #ifndef _WIN32
-# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM)
+# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM) && !defined(NO_BLOCKING_RANDOM_POLL)
 static int
 randombytes_block_on_dev_random(void)
 {
@@ -172,7 +172,7 @@ randombytes_salsa20_random_random_dev_open(void)
     const char **     device = devices;
     int               fd;
 
-# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM)
+# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM) && !defined(NO_BLOCKING_RANDOM_POLL)
     if (randombytes_block_on_dev_random() != 0) {
         return -1;
     }

--- a/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c
+++ b/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c
@@ -114,7 +114,7 @@ safe_read(const int fd, void * const buf_, size_t size)
 #endif
 
 #ifndef _WIN32
-# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM)
+# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM) && !defined(NO_BLOCKING_RANDOM_POLL)
 static int
 randombytes_block_on_dev_random(void)
 {
@@ -155,7 +155,7 @@ randombytes_sysrandom_random_dev_open(void)
     const char **      device = devices;
     int                fd;
 
-# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM)
+# if defined(__linux__) && !defined(USE_BLOCKING_RANDOM) && !defined(NO_BLOCKING_RANDOM_POLL)
     if (randombytes_block_on_dev_random() != 0) {
         return -1;
     }


### PR DESCRIPTION
Android emulators running on CentOS 6.0 *sometimes* block indefinitely on `/dev/random` access. 

This bug most likely exists in interaction between CentOS 6.0 and Android NDK, but adding this preprocessor and turning off blocking was a simpler fix to work around this problem.

The init code works ok with out the preprocessor defined on OS X and CentOS 7.0 and up.