### PR TITLE
GCC2 bug seeing empty statement at 2 semicolons

### DIFF
--- a/src/libsodium/sodium/utils.c
+++ b/src/libsodium/sodium/utils.c
@@ -62,7 +62,7 @@ static unsigned char canary[CANARY_SIZE];
 __attribute__ ((weak)) void
 _sodium_memzero_as_a_weak_symbol_to_prevent_lto(void * const pnt, const size_t len)
 {
-    unsigned char *pnt_ = (unsigned char *) pnt;;
+    unsigned char *pnt_ = (unsigned char *) pnt;
     size_t         i = (size_t) 0U;
 
     while (i < len) {


### PR DESCRIPTION
GCC2 breaks when it encounters a double semicolon due to parsing it as an empty statement before the variable declaration. Breaks compiling on Haiku.