### PR TITLE
WIP: crypto_pwhash constants

### DIFF
--- a/src/libsodium/crypto_pwhash/argon2/pwhash_argon2i.c
+++ b/src/libsodium/crypto_pwhash/argon2/pwhash_argon2i.c
@@ -20,6 +20,30 @@ crypto_pwhash_argon2i_alg_argon2i13(void)
 }
 
 size_t
+crypto_pwhash_argon2i_bytes_min(void)
+{
+    return crypto_pwhash_argon2i_BYTES_MIN;
+}
+
+size_t
+crypto_pwhash_argon2i_bytes_max(void)
+{
+    return crypto_pwhash_argon2i_BYTES_MAX;
+}
+
+size_t
+crypto_pwhash_argon2i_passwd_min(void)
+{
+    return crypto_pwhash_argon2i_PASSWD_MIN;
+}
+
+size_t
+crypto_pwhash_argon2i_passwd_max(void)
+{
+    return crypto_pwhash_argon2i_PASSWD_MAX;
+}
+
+size_t
 crypto_pwhash_argon2i_saltbytes(void)
 {
     return crypto_pwhash_argon2i_SALTBYTES;
@@ -35,6 +59,30 @@ const char *
 crypto_pwhash_argon2i_strprefix(void)
 {
     return crypto_pwhash_argon2i_STRPREFIX;
+}
+
+size_t
+crypto_pwhash_argon2i_opslimit_min(void)
+{
+    return crypto_pwhash_argon2i_OPSLIMIT_MIN;
+}
+
+size_t
+crypto_pwhash_argon2i_opslimit_max(void)
+{
+    return crypto_pwhash_argon2i_OPSLIMIT_MAX;
+}
+
+size_t
+crypto_pwhash_argon2i_memlimit_min(void)
+{
+    return crypto_pwhash_argon2i_MEMLIMIT_MIN;
+}
+
+size_t
+crypto_pwhash_argon2i_memlimit_max(void)
+{
+    return crypto_pwhash_argon2i_MEMLIMIT_MAX;
 }
 
 size_t

--- a/src/libsodium/crypto_pwhash/crypto_pwhash.c
+++ b/src/libsodium/crypto_pwhash/crypto_pwhash.c
@@ -16,6 +16,30 @@ crypto_pwhash_alg_default(void)
 }
 
 size_t
+crypto_pwhash_bytes_min(void)
+{
+    return crypto_pwhash_BYTES_MIN;
+}
+
+size_t
+crypto_pwhash_bytes_max(void)
+{
+    return crypto_pwhash_BYTES_MAX;
+}
+
+size_t
+crypto_pwhash_passwd_min(void)
+{
+    return crypto_pwhash_PASSWD_MIN;
+}
+
+size_t
+crypto_pwhash_passwd_max(void)
+{
+    return crypto_pwhash_PASSWD_MAX;
+}
+
+size_t
 crypto_pwhash_saltbytes(void)
 {
     return crypto_pwhash_SALTBYTES;
@@ -31,6 +55,30 @@ const char *
 crypto_pwhash_strprefix(void)
 {
     return crypto_pwhash_STRPREFIX;
+}
+
+size_t
+crypto_pwhash_opslimit_min(void)
+{
+    return crypto_pwhash_OPSLIMIT_MIN;
+}
+
+size_t
+crypto_pwhash_opslimit_max(void)
+{
+    return crypto_pwhash_OPSLIMIT_MAX;
+}
+
+size_t
+crypto_pwhash_memlimit_min(void)
+{
+    return crypto_pwhash_MEMLIMIT_MIN;
+}
+
+size_t
+crypto_pwhash_memlimit_max(void)
+{
+    return crypto_pwhash_MEMLIMIT_MAX;
 }
 
 size_t

--- a/src/libsodium/crypto_pwhash/scryptsalsa208sha256/pwhash_scryptsalsa208sha256.c
+++ b/src/libsodium/crypto_pwhash/scryptsalsa208sha256/pwhash_scryptsalsa208sha256.c
@@ -52,6 +52,30 @@ pickparams(unsigned long long opslimit, const size_t memlimit,
 }
 
 size_t
+crypto_pwhash_scryptsalsa208sha256_bytes_min(void)
+{
+    return crypto_pwhash_scryptsalsa208sha256_BYTES_MIN;
+}
+
+size_t
+crypto_pwhash_scryptsalsa208sha256_bytes_max(void)
+{
+    return crypto_pwhash_scryptsalsa208sha256_BYTES_MAX;
+}
+
+size_t
+crypto_pwhash_scryptsalsa208sha256_passwd_min(void)
+{
+    return crypto_pwhash_scryptsalsa208sha256_PASSWD_MIN;
+}
+
+size_t
+crypto_pwhash_scryptsalsa208sha256_passwd_max(void)
+{
+    return crypto_pwhash_scryptsalsa208sha256_PASSWD_MAX;
+}
+
+size_t
 crypto_pwhash_scryptsalsa208sha256_saltbytes(void)
 {
     return crypto_pwhash_scryptsalsa208sha256_SALTBYTES;
@@ -67,6 +91,30 @@ const char *
 crypto_pwhash_scryptsalsa208sha256_strprefix(void)
 {
     return crypto_pwhash_scryptsalsa208sha256_STRPREFIX;
+}
+
+size_t
+crypto_pwhash_scryptsalsa208sha256_opslimit_min(void)
+{
+    return crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_MIN;
+}
+
+size_t
+crypto_pwhash_scryptsalsa208sha256_opslimit_max(void)
+{
+    return crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_MAX;
+}
+
+size_t
+crypto_pwhash_scryptsalsa208sha256_memlimit_min(void)
+{
+    return crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_MIN;
+}
+
+size_t
+crypto_pwhash_scryptsalsa208sha256_memlimit_max(void)
+{
+    return crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_MAX;
 }
 
 size_t

--- a/src/libsodium/include/sodium/crypto_pwhash.h
+++ b/src/libsodium/include/sodium/crypto_pwhash.h
@@ -21,6 +21,22 @@ int crypto_pwhash_alg_argon2i13(void);
 SODIUM_EXPORT
 int crypto_pwhash_alg_default(void);
 
+#define crypto_pwhash_BYTES_MIN crypto_pwhash_argon2i_BYTES_MIN
+SODIUM_EXPORT
+size_t crypto_pwhash_bytes_min(void);
+
+#define crypto_pwhash_BYTES_MAX crypto_pwhash_argon2i_BYTES_MAX
+SODIUM_EXPORT
+size_t crypto_pwhash_bytes_max(void);
+
+#define crypto_pwhash_PASSWD_MIN crypto_pwhash_argon2i_PASSWD_MIN
+SODIUM_EXPORT
+size_t crypto_pwhash_passwd_min(void);
+
+#define crypto_pwhash_PASSWD_MAX crypto_pwhash_argon2i_PASSWD_MAX
+SODIUM_EXPORT
+size_t crypto_pwhash_passwd_max(void);
+
 #define crypto_pwhash_SALTBYTES crypto_pwhash_argon2i_SALTBYTES
 SODIUM_EXPORT
 size_t crypto_pwhash_saltbytes(void);
@@ -32,6 +48,22 @@ size_t crypto_pwhash_strbytes(void);
 #define crypto_pwhash_STRPREFIX crypto_pwhash_argon2i_STRPREFIX
 SODIUM_EXPORT
 const char *crypto_pwhash_strprefix(void);
+
+#define crypto_pwhash_OPSLIMIT_MIN crypto_pwhash_argon2i_OPSLIMIT_MIN
+SODIUM_EXPORT
+size_t crypto_pwhash_opslimit_min(void);
+
+#define crypto_pwhash_OPSLIMIT_MAX crypto_pwhash_argon2i_OPSLIMIT_MAX
+SODIUM_EXPORT
+size_t crypto_pwhash_opslimit_max(void);
+
+#define crypto_pwhash_MEMLIMIT_MIN crypto_pwhash_argon2i_MEMLIMIT_MIN
+SODIUM_EXPORT
+size_t crypto_pwhash_memlimit_min(void);
+
+#define crypto_pwhash_MEMLIMIT_MAX crypto_pwhash_argon2i_MEMLIMIT_MAX
+SODIUM_EXPORT
+size_t crypto_pwhash_memlimit_max(void);
 
 #define crypto_pwhash_OPSLIMIT_INTERACTIVE crypto_pwhash_argon2i_OPSLIMIT_INTERACTIVE
 SODIUM_EXPORT

--- a/src/libsodium/include/sodium/crypto_pwhash_argon2i.h
+++ b/src/libsodium/include/sodium/crypto_pwhash_argon2i.h
@@ -16,6 +16,22 @@ extern "C" {
 SODIUM_EXPORT
 int crypto_pwhash_argon2i_alg_argon2i13(void);
 
+#define crypto_pwhash_argon2i_BYTES_MIN ARGON2_MIN_OUTLEN
+SODIUM_EXPORT
+size_t crypto_pwhash_argon2i_bytes_min(void);
+
+#define crypto_pwhash_argon2i_BYTES_MAX ARGON2_MAX_OUTLEN
+SODIUM_EXPORT
+size_t crypto_pwhash_argon2i_bytes_max(void);
+
+#define crypto_pwhash_argon2i_PASSWD_MIN ARGON2_MIN_PWD_LENGTH
+SODIUM_EXPORT
+size_t crypto_pwhash_argon2i_passwd_min(void);
+
+#define crypto_pwhash_argon2i_PASSWD_MAX ARGON2_MAX_PWD_LENGTH
+SODIUM_EXPORT
+size_t crypto_pwhash_argon2i_passwd_max(void);
+
 #define crypto_pwhash_argon2i_SALTBYTES 16U
 SODIUM_EXPORT
 size_t crypto_pwhash_argon2i_saltbytes(void);
@@ -27,6 +43,22 @@ size_t crypto_pwhash_argon2i_strbytes(void);
 #define crypto_pwhash_argon2i_STRPREFIX "$argon2i$"
 SODIUM_EXPORT
 const char *crypto_pwhash_argon2i_strprefix(void);
+
+#define crypto_pwhash_argon2i_OPSLIMIT_MIN ARGON2_MIN_TIME
+SODIUM_EXPORT
+size_t crypto_pwhash_argon2i_opslimit_min(void);
+
+#define crypto_pwhash_argon2i_OPSLIMIT_MAX ARGON2_MAX_TIME
+SODIUM_EXPORT
+size_t crypto_pwhash_argon2i_opslimit_max(void);
+
+#define crypto_pwhash_argon2i_MEMLIMIT_MIN ARGON2_MIN_MEMORY
+SODIUM_EXPORT
+size_t crypto_pwhash_argon2i_memlimit_min(void);
+
+#define crypto_pwhash_argon2i_MEMLIMIT_MAX ARGON2_MAX_MEMORY
+SODIUM_EXPORT
+size_t crypto_pwhash_argon2i_memlimit_max(void);
 
 #define crypto_pwhash_argon2i_OPSLIMIT_INTERACTIVE 4ULL
 SODIUM_EXPORT

--- a/src/libsodium/include/sodium/crypto_pwhash_scryptsalsa208sha256.h
+++ b/src/libsodium/include/sodium/crypto_pwhash_scryptsalsa208sha256.h
@@ -13,6 +13,22 @@
 extern "C" {
 #endif
 
+#define crypto_pwhash_scryptsalsa208sha256_BYTES_MIN // XXX
+SODIUM_EXPORT
+size_t crypto_pwhash_scryptsalsa208sha256_bytes_min(void);
+
+#define crypto_pwhash_scryptsalsa208sha256_BYTES_MAX // XXX
+SODIUM_EXPORT
+size_t crypto_pwhash_scryptsalsa208sha256_bytes_max(void);
+
+#define crypto_pwhash_scryptsalsa208sha256_PASSWD_MIN // XXX
+SODIUM_EXPORT
+size_t crypto_pwhash_scryptsalsa208sha256_passwd_min(void);
+
+#define crypto_pwhash_scryptsalsa208sha256_PASSWD_MAX // XXX
+SODIUM_EXPORT
+size_t crypto_pwhash_scryptsalsa208sha256_passwd_max(void);
+
 #define crypto_pwhash_scryptsalsa208sha256_SALTBYTES 32U
 SODIUM_EXPORT
 size_t crypto_pwhash_scryptsalsa208sha256_saltbytes(void);
@@ -24,6 +40,22 @@ size_t crypto_pwhash_scryptsalsa208sha256_strbytes(void);
 #define crypto_pwhash_scryptsalsa208sha256_STRPREFIX "$7$"
 SODIUM_EXPORT
 const char *crypto_pwhash_scryptsalsa208sha256_strprefix(void);
+
+#define crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_MIN 32768
+SODIUM_EXPORT
+size_t crypto_pwhash_scryptsalsa208sha256_opslimit_min(void);
+
+#define crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_MAX // XXX
+SODIUM_EXPORT
+size_t crypto_pwhash_scryptsalsa208sha256_opslimit_max(void);
+
+#define crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_MIN // XXX
+SODIUM_EXPORT
+size_t crypto_pwhash_scryptsalsa208sha256_memlimit_min(void);
+
+#define crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_MAX // XXX
+SODIUM_EXPORT
+size_t crypto_pwhash_scryptsalsa208sha256_memlimit_max(void);
 
 #define crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_INTERACTIVE 524288ULL
 SODIUM_EXPORT

--- a/test/default/pwhash.c
+++ b/test/default/pwhash.c
@@ -320,9 +320,18 @@ int main(void)
                                  "password", strlen("password")) != -1) {
         printf("pwhash_str_verify(invalid(9)) failure\n");
     }
+    assert(crypto_pwhash_bytes_min() > 0U);
+    assert(crypto_pwhash_bytes_max() > 0U);
+    assert(crypto_pwhash_passwd_min() > 0U);
+    assert(crypto_pwhash_passwd_max() > 0U);
     assert(crypto_pwhash_saltbytes() > 0U);
     assert(crypto_pwhash_strbytes() > 1U);
     assert(crypto_pwhash_strbytes() > strlen(crypto_pwhash_strprefix()));
+
+    assert(crypto_pwhash_opslimit_min() > 0U);
+    assert(crypto_pwhash_opslimit_max() > 0U);
+    assert(crypto_pwhash_memlimit_min() > 0U);
+    assert(crypto_pwhash_memlimit_max() > 0U);
     assert(crypto_pwhash_opslimit_interactive() > 0U);
     assert(crypto_pwhash_memlimit_interactive() > 0U);
     assert(crypto_pwhash_opslimit_moderate() > 0U);
@@ -331,6 +340,17 @@ int main(void)
     assert(crypto_pwhash_memlimit_sensitive() > 0U);
     assert(strcmp(crypto_pwhash_primitive(), "argon2i") == 0);
 
+    assert(crypto_pwhash_bytes_min() == crypto_pwhash_BYTES_MIN);
+    assert(crypto_pwhash_bytes_max() == crypto_pwhash_BYTES_MAX);
+    assert(crypto_pwhash_passwd_min() == crypto_pwhash_PASSWD_MIN);
+    assert(crypto_pwhash_passwd_max() == crypto_pwhash_PASSWD_MAX);
+    assert(crypto_pwhash_saltbytes() == crypto_pwhash_SALTBYTES);
+    assert(crypto_pwhash_strbytes() == crypto_pwhash_STRBYTES);
+
+    assert(crypto_pwhash_opslimit_min() == crypto_pwhash_OPSLIMIT_MIN);
+    assert(crypto_pwhash_opslimit_max() == crypto_pwhash_OPSLIMIT_MAX);
+    assert(crypto_pwhash_memlimit_min() == crypto_pwhash_MEMLIMIT_MIN);
+    assert(crypto_pwhash_memlimit_max() == crypto_pwhash_MEMLIMIT_MAX);
     assert(crypto_pwhash_opslimit_interactive() == crypto_pwhash_OPSLIMIT_INTERACTIVE);
     assert(crypto_pwhash_memlimit_interactive() == crypto_pwhash_MEMLIMIT_INTERACTIVE);
     assert(crypto_pwhash_opslimit_moderate() == crypto_pwhash_OPSLIMIT_MODERATE);
@@ -338,9 +358,17 @@ int main(void)
     assert(crypto_pwhash_opslimit_sensitive() == crypto_pwhash_OPSLIMIT_SENSITIVE);
     assert(crypto_pwhash_memlimit_sensitive() == crypto_pwhash_MEMLIMIT_SENSITIVE);
 
+    assert(crypto_pwhash_argon2i_bytes_min() == crypto_pwhash_bytes_min());
+    assert(crypto_pwhash_argon2i_bytes_max() == crypto_pwhash_bytes_max());
+    assert(crypto_pwhash_argon2i_passwd_min() == crypto_pwhash_passwd_min());
+    assert(crypto_pwhash_argon2i_passwd_max() == crypto_pwhash_passwd_max());
     assert(crypto_pwhash_argon2i_saltbytes() == crypto_pwhash_saltbytes());
     assert(crypto_pwhash_argon2i_strbytes() == crypto_pwhash_strbytes());
     assert(strcmp(crypto_pwhash_argon2i_strprefix(), crypto_pwhash_strprefix()) == 0);
+    assert(crypto_pwhash_argon2i_opslimit_min() == crypto_pwhash_opslimit_min());
+    assert(crypto_pwhash_argon2i_opslimit_max() == crypto_pwhash_opslimit_max());
+    assert(crypto_pwhash_argon2i_memlimit_min() == crypto_pwhash_memlimit_min());
+    assert(crypto_pwhash_argon2i_memlimit_max() == crypto_pwhash_memlimit_max());
     assert(crypto_pwhash_argon2i_opslimit_interactive() ==
            crypto_pwhash_opslimit_interactive());
     assert(crypto_pwhash_argon2i_opslimit_moderate() ==

--- a/test/default/pwhash_scrypt.c
+++ b/test/default/pwhash_scrypt.c
@@ -330,10 +330,19 @@ int main(void)
     str_out[14]--;
 
     assert(str_out[crypto_pwhash_scryptsalsa208sha256_STRBYTES - 1U] == 0);
+    assert(crypto_pwhash_scryptsalsa208sha256_bytes_min() > 0U);
+    assert(crypto_pwhash_scryptsalsa208sha256_bytes_max() > 0U);
+    assert(crypto_pwhash_scryptsalsa208sha256_passwd_min() > 0U);
+    assert(crypto_pwhash_scryptsalsa208sha256_passwd_max() > 0U);
     assert(crypto_pwhash_scryptsalsa208sha256_saltbytes() > 0U);
     assert(crypto_pwhash_scryptsalsa208sha256_strbytes() > 1U);
     assert(crypto_pwhash_scryptsalsa208sha256_strbytes() >
            strlen(crypto_pwhash_scryptsalsa208sha256_strprefix()));
+
+    assert(crypto_pwhash_scryptsalsa208sha256_opslimit_min() > 0U);
+    assert(crypto_pwhash_scryptsalsa208sha256_opslimit_max() > 0U);
+    assert(crypto_pwhash_scryptsalsa208sha256_memlimit_min() > 0U);
+    assert(crypto_pwhash_scryptsalsa208sha256_memlimit_max() > 0U);
     assert(crypto_pwhash_scryptsalsa208sha256_opslimit_interactive() > 0U);
     assert(crypto_pwhash_scryptsalsa208sha256_memlimit_interactive() > 0U);
     assert(crypto_pwhash_scryptsalsa208sha256_opslimit_sensitive() > 0U);


### PR DESCRIPTION
I've attemted a PR for #457, and tried to expose a uniform API for both `crypto_pwhash`, `crypto_pwhash_argon2i` and `crypto_pwhash_scryptsalsa208sha256`, however I have some standing issues before this PR is finished:

* I was only able to read off one hard limit for scrypt, namely `OPSLIMIT_MIN` as that's simply overridden if too low
* Due to my inexperience with C, I wasn't able to import the `argon2.h` header file. Should all the limits from there simply be copy/pasted into the `crypto_pwhash_argon2i.h` header file? That seems to have been the case for all other header files, however some constants are resolved at compile time (?) it seems, like the memlimit.

I have a PR for `libsodium-docs` that will follow shortly.