### PR TITLE
Add constant-time Base64 encoding and decoding

### DIFF
--- a/src/libsodium/include/sodium/utils.h
+++ b/src/libsodium/include/sodium/utils.h
@@ -62,6 +62,15 @@ int sodium_hex2bin(unsigned char * const bin, const size_t bin_maxlen,
                    const char ** const hex_end);
 
 SODIUM_EXPORT
+char *sodium_bin2base64(char * const base64, const size_t base64_maxlen,
+                        const unsigned char * const bin, const size_t bin_len);
+
+SODIUM_EXPORT
+int sodium_base642bin(unsigned char * const bin, const size_t bin_maxlen,
+                      const char * const hex, const size_t hex_len,
+                      size_t * const bin_len, const char ** const base64_end);
+
+SODIUM_EXPORT
 int sodium_mlock(void * const addr, const size_t len);
 
 SODIUM_EXPORT

--- a/test/default/sodium_utils.c
+++ b/test/default/sodium_utils.c
@@ -197,8 +197,10 @@ main(void)
     }
     printf("\n");
     printf("%s\n", sodium_bin2base64(buf3, sizeof buf3, buf1, i));
-    printf("%s\n", sodium_bin2base64(buf3, sizeof buf3, "a", 1U));
-    printf("%s\n", sodium_bin2base64(buf3, sizeof buf3, "BC", 2U));
+    memcpy(buf1, "a", 1U);
+    printf("%s\n", sodium_bin2base64(buf3, sizeof buf3, buf1, 1U));
+    memcpy(buf1, "BC", 2U);
+    printf("%s\n", sodium_bin2base64(buf3, sizeof buf3, buf1, 2U));
     if (sodium_base642bin(buf1, 8U, b64, 64, &bin_len, &b64_end) !=
         -1) {
         printf("sodium_base642bin() overflow\n");

--- a/test/default/sodium_utils.c
+++ b/test/default/sodium_utils.c
@@ -9,12 +9,14 @@ main(void)
     unsigned char buf2[1000];
     unsigned char buf1_rev[1000];
     unsigned char buf2_rev[1000];
-    char          buf3[33];
+    char          buf3[65];
     unsigned char buf4[4];
     unsigned char nonce[24];
     char          nonce_hex[49];
     const char *  hex;
     const char *  hex_end;
+    const char *  b64;
+    const char *  b64_end;
     size_t        bin_len;
     unsigned int  i;
     unsigned int  j;
@@ -183,6 +185,49 @@ main(void)
     sodium_add(nonce, nonce, 24U);
     printf("%s\n",
            sodium_bin2hex(nonce_hex, sizeof nonce_hex, nonce, sizeof nonce));
+
+    b64 = "/+9876543210zyxwvutsrqponmlkjihgfedcba"
+        "ZYXWVUTSRQPONMLKJIHGFEDCBA";
+    if (sodium_base642bin(buf1, sizeof buf1, b64, 64, &bin_len, &b64_end) !=
+        0) {
+        printf("sodium_base642bin() with all characters\n");
+    }
+    for (i = 0; i < 48; i += 3) {
+        printf("%02x%02x%02x ", buf1[i+0], buf1[i+1], buf1[i+2]);
+    }
+    printf("\n");
+    printf("%s\n", sodium_bin2base64(buf3, sizeof buf3, buf1, i));
+    printf("%s\n", sodium_bin2base64(buf3, sizeof buf3, "a", 1U));
+    printf("%s\n", sodium_bin2base64(buf3, sizeof buf3, "BC", 2U));
+    if (sodium_base642bin(buf1, 8U, b64, 64, &bin_len, &b64_end) !=
+        -1) {
+        printf("sodium_base642bin() overflow\n");
+    }
+    printf("du1: %ld %ld\n", (long) (b64_end - b64), (long) bin_len);
+    b64 = "ab_";
+    if (sodium_base642bin(buf1, sizeof buf1, b64, 3U, &bin_len, &b64_end) !=
+        0) {
+        printf("sodium_base642bin() invalid characters\n");
+    }
+    printf("du2: %ld %ld\n", (long) (b64_end - b64), (long) bin_len);
+    b64 = "abcd_";
+    if (sodium_base642bin(buf1, sizeof buf1, b64, 5U, &bin_len, &b64_end) !=
+        -1) {
+        printf("sodium_base642bin() invalid base64 length\n");
+    }
+    printf("du3: %ld %ld\n", (long) (b64_end - b64), (long) bin_len);
+    b64 = "ab==";
+    if (sodium_base642bin(buf1, sizeof buf1, b64, 4U, &bin_len, &b64_end) !=
+        0) {
+        printf("sodium_base642bin() with padding\n");
+    }
+    printf("du4: %ld %ld\n", (long) (b64_end - b64), (long) bin_len);
+    b64 = "abcdefg_";
+    if (sodium_base642bin(buf1, sizeof buf1, b64, 7U, &bin_len, &b64_end) !=
+        0) {
+        printf("sodium_base642bin() three trailing bytes\n");
+    }
+    printf("du5: %ld %ld\n", (long) (b64_end - b64), (long) bin_len);
 
     return 0;
 }

--- a/test/default/sodium_utils.exp
+++ b/test/default/sodium_utils.exp
@@ -22,3 +22,12 @@ dt5: 11
 fcfffffffffffbfdfefefefefefefefefefefefefefefefe
 fcfffffffffffffffffffbfdfefefefefefefefefefefefe
 fcfffffffffffffffffffffffffffffffffffffffffffbfd
+ffef7c efae78 df6d74 cf2c70 beeb6c aeaa68 9e6964 8e2860 7de75c 6da658 5d6554 4d2450 3ce34c 2ca248 1c6144 0c2040 
+/+9876543210zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA
+YQ
+QkM
+du1: 12 8
+du2: 0 0
+du3: 4 3
+du4: 2 1
+du5: 7 5


### PR DESCRIPTION
This should address #438.

I based this on the C++ version by Sc00bz (linked in #438), but took the liberty of handling padding in constant time by reducing b64_len.

This code assumes two's complement representation of signed integers; is that worth avoiding?