### PR TITLE
Fix ref10 slide on PPC-VLE

### DIFF
--- a/src/libsodium/crypto_core/curve25519/ref10/curve25519_ref10.c
+++ b/src/libsodium/crypto_core/curve25519/ref10/curve25519_ref10.c
@@ -1359,6 +1359,8 @@ slide(signed char *r, const unsigned char *a)
     int i;
     int b;
     int k;
+    int ribs;
+    int cmp;
 
     for (i = 0; i < 256; ++i) {
         r[i] = 1 & (a[i >> 3] >> (i & 7));
@@ -1367,20 +1369,25 @@ slide(signed char *r, const unsigned char *a)
         if (r[i]) {
             for (b = 1; b <= 6 && i + b < 256; ++b) {
                 if (r[i + b]) {
-                    if (r[i] + (r[i + b] << b) <= 15) {
-                        r[i] += r[i + b] << b;
+                    ribs = r[i + b] << b;
+                    cmp = r[i] + ribs;
+                    if (cmp <= 15) {
+                        r[i] = cmp; 
                         r[i + b] = 0;
-                    } else if (r[i] - (r[i + b] << b) >= -15) {
-                        r[i] -= r[i + b] << b;
-                        for (k = i + b; k < 256; ++k) {
-                            if (!r[k]) {
-                                r[k] = 1;
-                                break;
-                            }
-                            r[k] = 0;
-                        }
                     } else {
-                        break;
+                        cmp = r[i] - ribs;
+                        if (cmp >= -15) {
+                            r[i] = cmp;
+                            for (k = i + b;k < 256;++k) {
+                                if (!r[k]) {
+                                    r[k] = 1;
+                                    break;
+                                }
+                                r[k] = 0;
+                            }
+                        } else {
+                            break;
+                        }
                     }
                 }
             }

--- a/src/libsodium/crypto_core/curve25519/ref10/curve25519_ref10.c
+++ b/src/libsodium/crypto_core/curve25519/ref10/curve25519_ref10.c
@@ -1378,7 +1378,7 @@ slide(signed char *r, const unsigned char *a)
                         cmp = r[i] - ribs;
                         if (cmp >= -15) {
                             r[i] = cmp;
-                            for (k = i + b;k < 256;++k) {
+                            for (k = i + b; k < 256; ++k) {
                                 if (!r[k]) {
                                     r[k] = 1;
                                     break;


### PR DESCRIPTION
I have added some intermediate variables to slide() which removes whatever ambiguity was causing the crash with optimization flags on PPC_VLE architecture.  An added bonus is that, at least on PPC, the resultant assembly code is somewhat smaller, and probably faster.

I have forced the project to build using REF10 by removing ASM defines from the Makefile after ./configure, and it passes all 65 tests (at least on OSX)