### PR TITLE
Replace `which` with `command` for portability

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,20 +6,25 @@ else
   LIBTOOLIZE='libtoolize'
 fi
 
-if [ ! -x "`which $LIBTOOLIZE 2>/dev/null`" ] ; then
+command -v command >/dev/null 2>&1 || {
+  echo "command is required, but wasn't found on this system"
+  exit 1
+}
+
+command -v $LIBTOOLIZE >/dev/null 2>&1 || {
   echo "libtool is required, but wasn't found on this system"
   exit 1
-fi
+}
 
-if [ ! -x "`which autoconf 2>/dev/null`" ] ; then
+command -v autoconf >/dev/null 2>&1 || {
   echo "autoconf is required, but wasn't found on this system"
   exit 1
-fi
+}
 
-if [ ! -x "`which automake 2>/dev/null`" ] ; then
+command -v automake >/dev/null 2>&1 || {
   echo "automake is required, but wasn't found on this system"
   exit 1
-fi
+}
 
 if autoreconf --version > /dev/null 2>&1 ; then
   exec autoreconf -ivf

--- a/test/default/nacl-test-wrapper.sh
+++ b/test/default/nacl-test-wrapper.sh
@@ -16,7 +16,10 @@ else
   fi
 fi
 
-which python >/dev/null 2>&1 || \
+command -v command >/dev/null 2>&1 || \
+  { echo "command is required, but wasn't found on this system"; exit 1; }
+
+command -v python >/dev/null 2>&1 || \
   { echo >&2 "Python not found. Aborting."; exit 1; }
 
 SEL_LDR=$(find "$NACL_SDK_ROOT" -name sel_ldr.py | head -n 1)


### PR DESCRIPTION
The `which` command is not part of the posix standard and not available
in some environments.  The `command` command is part of the posix
standard and well supported.

See https://unix.stackexchange.com/q/85249 for a discussion about the
use of `command` instead of `which`.

If a system had `libtool` but not `which`, the build process would issue
an erroneous error stating:

    libtool is required, but wasn't found on this system

Switching to `command` corrects this problem.