### PR TITLE
[.NET nuget] support .NET framework >= 4.6

### DIFF
--- a/packaging/dotnet-core/desktop.targets
+++ b/packaging/dotnet-core/desktop.targets
@@ -1,0 +1,16 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x86\native\libsodium.dll">
+            <Link>x86\libsodium.dll</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+            <Visible>false</Visible>
+        </None>
+        <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win7-x64\native\libsodium.dll">
+            <Link>x64\libsodium.dll</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+            <Visible>false</Visible>
+        </None>
+    </ItemGroup>
+</Project>

--- a/packaging/dotnet-core/libsodium.props
+++ b/packaging/dotnet-core/libsodium.props
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Project>
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard1.1;net46</TargetFrameworks>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -23,5 +23,6 @@
     <Content Include="AUTHORS" PackagePath="" />
     <Content Include="ChangeLog" PackagePath="" />
     <Content Include="runtimes\**\*.*" PackagePath="runtimes\" />
+    <Content Include="build\**\*.*" PackagePath="build\" />
   </ItemGroup>
 </Project>

--- a/packaging/dotnet-core/prepare.py
+++ b/packaging/dotnet-core/prepare.py
@@ -42,6 +42,7 @@ LINUX = [
 EXTRAS = [ 'LICENSE', 'AUTHORS', 'ChangeLog' ]
 
 PROPSFILE = 'libsodium.props'
+DESKTOPTARGETSFILE = 'desktop.targets'
 MAKEFILE = 'Makefile'
 BUILDDIR = 'build'
 CACHEDIR = 'cache'
@@ -64,6 +65,7 @@ class Version:
     self.projfile = os.path.join(self.builddir, '{0}.pkgproj'.format(PACKAGE))
     self.propsfile = os.path.join(self.builddir, '{0}.props'.format(PACKAGE))
     self.pkgfile = os.path.join(BUILDDIR, '{0}.{1}.nupkg'.format(PACKAGE, self.version))
+    self.desktoptargetsfile = os.path.join(self.builddir, 'build', 'net46', '{0}.targets'.format(PACKAGE))
 
 class WindowsItem:
 
@@ -203,6 +205,11 @@ def main(args):
       item.make(f)
 
     f.write('\n')
+    f.write('{0}: {1}\n'.format(version.desktoptargetsfile, DESKTOPTARGETSFILE))
+    f.write('\t@mkdir -p $(dir $@)\n')
+    f.write('\tcp -f $< $@\n')
+
+    f.write('\n')
     f.write('{0}: {1}\n'.format(version.propsfile, PROPSFILE))
     f.write('\t@mkdir -p $(dir $@)\n')
     f.write('\tcp -f $< $@\n')
@@ -222,6 +229,7 @@ def main(args):
     f.write('{0}:'.format(version.pkgfile))
     f.write(' \\\n\t\t{0}'.format(version.projfile))
     f.write(' \\\n\t\t{0}'.format(version.propsfile))
+    f.write(' \\\n\t\t{0}'.format(version.desktoptargetsfile))
     for item in items:
       f.write(' \\\n\t\t{0}'.format(item.packfile))
     f.write('\n')


### PR DESCRIPTION
Add MSBuild targets for net46 target framework which copy both x86 and
x64 libsodium binaries into corresponding folders. This allows AnyCPU
applications to load the appropriate binary at runtime via
`LoadLibraryEx`.

The solution is inspired by what the SQLitePCL.raw people are deploying and should be sufficient for most use cases. Known exceptions are:
* Shadow Copying (Haven't looked too deeply into this, but it looks like there is no general solution)
* Mono (actually I haven't tested this, but I'm pretty sure there is some additional stuff necessary)

/cc @ektrah 
/xref #504