### PR TITLE
Fixed project file where one too many lines was removed from project files

### DIFF
--- a/builds/msvc/properties/Win32.props
+++ b/builds/msvc/properties/Win32.props
@@ -9,6 +9,9 @@
     <ClCompile>
       <PreprocessorDefinitions>WIN32;_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>Win32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>

--- a/builds/msvc/properties/x64.props
+++ b/builds/msvc/properties/x64.props
@@ -12,6 +12,9 @@
       these are sometimes required even for 64 bit builds and should never cause harm there.-->
       <PreprocessorDefinitions>WIN32;_WIN32;WIN64;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>x64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
     <Link>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>

--- a/builds/msvc/vs2010/libsodium/libsodium.vcxproj
+++ b/builds/msvc/vs2010/libsodium/libsodium.vcxproj
@@ -308,4 +308,5 @@
     <ResourceCompile Include="..\..\resource.rc">
     </ResourceCompile>
   </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/builds/msvc/vs2012/libsodium/libsodium.vcxproj
+++ b/builds/msvc/vs2012/libsodium/libsodium.vcxproj
@@ -308,4 +308,5 @@
     <ResourceCompile Include="..\..\resource.rc">
     </ResourceCompile>
   </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/builds/msvc/vs2013/libsodium/libsodium.vcxproj
+++ b/builds/msvc/vs2013/libsodium/libsodium.vcxproj
@@ -308,4 +308,5 @@
     <ResourceCompile Include="..\..\resource.rc">
     </ResourceCompile>
   </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/builds/msvc/vs2015/libsodium/libsodium.vcxproj
+++ b/builds/msvc/vs2015/libsodium/libsodium.vcxproj
@@ -308,4 +308,5 @@
     <ResourceCompile Include="..\..\resource.rc">
     </ResourceCompile>
   </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/builds/msvc/vs2017/libsodium/libsodium.vcxproj
+++ b/builds/msvc/vs2017/libsodium/libsodium.vcxproj
@@ -308,4 +308,5 @@
     <ResourceCompile Include="..\..\resource.rc">
     </ResourceCompile>
   </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION
Fixed project file where one too many lines was removed from project file in change 87473fd causing the projects to not build.