### PR TITLE
Update packaging for .NET Core

### DIFF
--- a/packaging/dotnet-core/README.md
+++ b/packaging/dotnet-core/README.md
@@ -1,5 +1,9 @@
 This directory contains scripts and files to package libsodium for .NET Core.
 
+*Note:* The NuGet package is intended for the implementation of language
+bindings such as [NSec](https://github.com/ektrah/nsec). It does not provide a
+.NET API itself.
+
 In .NET Core, it is customary to provide pre-compiled binaries for all platforms
 as NuGet packages. The purpose of the `prepare.py` script in this directory is
 to generate a `Makefile` that downloads and builds libsodium binaries for a
@@ -17,25 +21,39 @@ See `prepare.py` for the complete list of supported platforms.
 The metadata for the NuGet package is located in `libsodium.props`.
 
 
-**Making a pre-release**
+**Versioning**
 
-1. Run `python3 prepare.py 1.0.13-preview-01` to generate the `Makefile`.
-   `1.0.13` is the libsodium version number; `01` is the pre-release
-   number and needs to be incremented for each pre-release.
-2. Take a look at the generated `Makefile`. It uses `sudo` a few times.
-3. Run `make` to download and build the binaries and create the NuGet
-   package. You may need to install `docker`, `make`, `curl`, `tar` and
-   `unzip` first. The NuGet package is output as a `.nupkg` file in the
-   `build` directory.
-4. Grab a cup of coffee. Downloading the Docker images and compiling the
-   Linux binaries takes a while.
-5. Verify that everything in the `.nupkg` file is in place.
-6. Publish the release by uploading the `.nupkg` file to 
-   [nuget.org](https://nuget.org/).
+Version numbers for the packages for .NET Core consist of three components:
+
+* *libsodium version*  
+  The libsodium version is in the format `X.Y.Z`.
+* *package revision*  
+  It may be necessary to release more than one package for a libsodium version,
+  e.g., when adding support for a new platform or if a release contains a broken
+  binary. In this case, a package revision number is added as a fourth part to
+  the libsodium version, starting at `1`. For example, `1.0.13` is the initial
+  release of the package for libsodium 1.0.13 and `1.0.13.5` is the fifth
+  revision (sixth release) of that package.
+* *pre-release label*  
+  If a package is a pre-release, a label is appended to the version number in
+  `-preview-##` format where `##` is the number of the pre-release, starting at
+  `01`. For example, `1.0.13-preview-01` is the first pre-release of the package
+  for libsodium 1.0.13 and `1.0.13.5-preview-02` the second pre-release of the
+  fifth revision of the package for libsodium 1.0.13.
 
 
 **Making a release**
 
-1. Run `python3 prepare.py 1.0.13` to generate the `Makefile`.
-
-The remaining steps are the same.
+1. Update any existing Docker images.
+2. Run `python3 prepare.py <version>` to generate the `Makefile`, where
+   `<version>` is the package version number in the format described above.
+3. Take a look at the generated `Makefile`. It uses `sudo` a few times.
+4. Run `make` to download and build the binaries and create the NuGet package.
+   You may need to install `docker`, `make`, `curl`, `tar` and `unzip` first.
+5. Grab a cup of coffee. Downloading the Docker images and compiling the Linux
+   binaries takes a while. When done, the NuGet package is output as a `.nupkg`
+   file in the `build` directory.
+6. Run `make test` to perform a quick test of the NuGet package. Verify that
+   everything else in the `.nupkg` file is in place.
+7. Publish the release by uploading the `.nupkg` file to
+   [nuget.org](https://nuget.org/).

--- a/packaging/dotnet-core/libsodium.props
+++ b/packaging/dotnet-core/libsodium.props
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <Project>
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net46</TargetFrameworks>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
@@ -8,6 +9,7 @@
     <PackageOutputPath>$(MSBuildProjectDirectory)</PackageOutputPath>
     <ProjectFileToPack>$(MSBuildProjectFullPath)</ProjectFileToPack>
   </PropertyGroup>
+
   <PropertyGroup>
     <PackageId>libsodium</PackageId>
     <Version><!-- set by prepare.py --></Version>
@@ -17,7 +19,9 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://raw.githubusercontent.com/jedisct1/libsodium/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://libsodium.org/</PackageProjectUrl>
+    <MinClientVersion>4.0</MinClientVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <Content Include="LICENSE" PackagePath="" />
     <Content Include="AUTHORS" PackagePath="" />
@@ -25,9 +29,5 @@
     <Content Include="runtimes\**\*.*" PackagePath="runtimes\" />
     <Content Include="build\**\*.*" PackagePath="build\" />
   </ItemGroup>
-  <ItemDefinitionGroup>
-    <Link>
-      <AdditionalDependencies>advapi32.lib</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
+
 </Project>

--- a/packaging/dotnet-core/prepare.py
+++ b/packaging/dotnet-core/prepare.py
@@ -24,19 +24,19 @@ MACOS = [
 ]
 
 LINUX = [
-  # --------------------- ------------------
-  # Runtime ID            Docker Image
-  # --------------------- ------------------
-  ( 'alpine.3-x64',       'alpine:3.4'      ),
+  # --------------------- ----------------- #
+  # Runtime ID            Docker Image      #
+  # --------------------- ----------------- #
   ( 'centos.7-x64',       'centos:7.1.1503' ),
   ( 'debian.8-x64',       'debian:8.2'      ),
   ( 'fedora.24-x64',      'fedora:24'       ),
   ( 'fedora.25-x64',      'fedora:25'       ),
+  ( 'fedora.26-x64',      'fedora:26'       ),
   ( 'opensuse.42.1-x64',  'opensuse:42.1'   ),
   ( 'ubuntu.14.04-x64',   'ubuntu:trusty'   ),
   ( 'ubuntu.16.04-x64',   'ubuntu:xenial'   ),
   ( 'ubuntu.16.10-x64',   'ubuntu:yakkety'  ),
-  # --------------------- ------------------
+  # --------------------- ----------------- #
 ]
 
 EXTRAS = [ 'LICENSE', 'AUTHORS', 'ChangeLog' ]
@@ -55,22 +55,21 @@ DOCKER = 'sudo docker'
 
 class Version:
 
-  def __init__(self, prefix, suffix):
-    self.prefix = prefix
-    self.suffix = suffix
-    self.version = prefix + '-' + suffix if suffix is not None else prefix
+  def __init__(self, libsodium_version, package_version):
+    self.libsodium_version = libsodium_version
+    self.package_version = package_version
 
-    self.builddir = os.path.join(BUILDDIR, prefix)
-    self.tempdir = os.path.join(TEMPDIR, prefix)
-    self.projfile = os.path.join(self.builddir, '{0}.pkgproj'.format(PACKAGE))
+    self.builddir = os.path.join(BUILDDIR, libsodium_version)
+    self.tempdir = os.path.join(TEMPDIR, libsodium_version)
+    self.projfile = os.path.join(self.builddir, '{0}.{1}.pkgproj'.format(PACKAGE, package_version))
     self.propsfile = os.path.join(self.builddir, '{0}.props'.format(PACKAGE))
-    self.pkgfile = os.path.join(BUILDDIR, '{0}.{1}.nupkg'.format(PACKAGE, self.version))
+    self.pkgfile = os.path.join(BUILDDIR, '{0}.{1}.nupkg'.format(PACKAGE, package_version))
     self.desktoptargetsfile = os.path.join(self.builddir, 'build', 'net46', '{0}.targets'.format(PACKAGE))
 
 class WindowsItem:
 
   def __init__(self, version, rid, platform):
-    self.url = 'https://download.libsodium.org/libsodium/releases/libsodium-{0}-msvc.zip'.format(version.prefix)
+    self.url = 'https://download.libsodium.org/libsodium/releases/libsodium-{0}-msvc.zip'.format(version.libsodium_version)
     self.cachefile = os.path.join(CACHEDIR, re.sub(r'[^A-Za-z0-9.]', '-', self.url))
     self.packfile = os.path.join(version.builddir, 'runtimes', rid, 'native', LIBRARY + '.dll')
     self.itemfile = '{0}/Release/v140/dynamic/libsodium.dll'.format(platform)
@@ -94,10 +93,10 @@ class WindowsItem:
 class MacOSItem:
 
   def __init__(self, version, rid, codename):
-    self.url = 'https://bintray.com/homebrew/bottles/download_file?file_path=libsodium-{0}.{1}.bottle.tar.gz'.format(version.prefix, codename)
+    self.url = 'https://bintray.com/homebrew/bottles/download_file?file_path=libsodium-{0}.{1}.bottle.tar.gz'.format(version.libsodium_version, codename)
     self.cachefile = os.path.join(CACHEDIR, re.sub(r'[^A-Za-z0-9.]', '-', self.url))
     self.packfile = os.path.join(version.builddir, 'runtimes', rid, 'native', LIBRARY + '.dylib')
-    self.itemfile = 'libsodium/{0}/lib/libsodium.dylib'.format(version.prefix)
+    self.itemfile = 'libsodium/{0}/lib/libsodium.dylib'.format(version.libsodium_version)
     self.tempdir = os.path.join(version.tempdir, rid)
     self.tempfile = os.path.join(self.tempdir, os.path.normpath(self.itemfile))
 
@@ -118,9 +117,11 @@ class MacOSItem:
 class LinuxItem:
 
   def __init__(self, version, rid, docker_image):
-    self.url = 'https://download.libsodium.org/libsodium/releases/libsodium-{0}.tar.gz'.format(version.prefix)
+    self.url = 'https://download.libsodium.org/libsodium/releases/libsodium-{0}.tar.gz'.format(version.libsodium_version)
     self.cachefile = os.path.join(CACHEDIR, re.sub(r'[^A-Za-z0-9.]', '-', self.url))
     self.packfile = os.path.join(version.builddir, 'runtimes', rid, 'native', LIBRARY + '.so')
+    self.tempdir = os.path.join(version.tempdir, rid)
+    self.tempfile = os.path.join(self.tempdir, 'libsodium.so')
     self.docker_image = docker_image
     self.recipe = rid
 
@@ -137,7 +138,11 @@ class LinuxItem:
         recipe = m.group(1) + m.group(3) + m.group(5)
 
     f.write('\n')
-    f.write('{0}: {1}\n'.format(self.packfile, self.cachefile))
+    f.write('{0}: {1}\n'.format(self.packfile, self.tempfile))
+    f.write('\t@mkdir -p $(dir $@)\n')
+    f.write('\tcp -f $< $@\n')
+    f.write('\n')
+    f.write('{0}: {1}\n'.format(self.tempfile, self.cachefile))
     f.write('\t@mkdir -p $(dir $@)\n')
     f.write('\t{0} run --rm '.format(DOCKER) +
             '-v $(abspath recipes):/io/recipes ' +
@@ -148,11 +153,11 @@ class LinuxItem:
 class ExtraItem:
 
   def __init__(self, version, filename):
-    self.url = 'https://download.libsodium.org/libsodium/releases/libsodium-{0}.tar.gz'.format(version.prefix)
+    self.url = 'https://download.libsodium.org/libsodium/releases/libsodium-{0}.tar.gz'.format(version.libsodium_version)
     self.cachefile = os.path.join(CACHEDIR, re.sub(r'[^A-Za-z0-9.]', '-', self.url))
     self.packfile = os.path.join(version.builddir, filename)
-    self.itemfile = 'libsodium-{0}/{1}'.format(version.prefix, filename)
-    self.tempdir = version.tempdir
+    self.itemfile = 'libsodium-{0}/{1}'.format(version.libsodium_version, filename)
+    self.tempdir = os.path.join(version.tempdir, 'extras')
     self.tempfile = os.path.join(self.tempdir, os.path.normpath(self.itemfile))
 
   def make(self, f):
@@ -170,20 +175,23 @@ class ExtraItem:
     ))
 
 def main(args):
-  m = re.fullmatch(r'(\d+(?:\.\d+){1,3})(?:-(\w+(?:[_.-]\w+)*))?', args[1]) if len(args) == 2 else None
+  m = re.fullmatch(r'((\d+\.\d+\.\d+)(\.\d+)?)(?:-(\w+(?:[_.-]\w+)*))?', args[1]) if len(args) == 2 else None
 
   if m is None:
     print('Usage:')
-    print('       python3 prepare.py <version>[-preview-##]')
+    print('       python3 prepare.py <version>')
     print()
     print('Examples:')
     print('       python3 prepare.py 1.0.13-preview-01')
     print('       python3 prepare.py 1.0.13-preview-02')
     print('       python3 prepare.py 1.0.13-preview-03')
     print('       python3 prepare.py 1.0.13')
+    print('       python3 prepare.py 1.0.13.1-preview-01')
+    print('       python3 prepare.py 1.0.13.1')
+    print('       python3 prepare.py 1.0.13.2')
     return 1
 
-  version = Version(m.group(1), m.group(2))
+  version = Version(m.group(2), m.group(0))
 
   items = [ WindowsItem(version, rid, platform)   for (rid, platform) in WINDOWS   ] + \
           [ MacOSItem(version, rid, codename)     for (rid, codename) in MACOS     ] + \
@@ -221,7 +229,7 @@ def main(args):
             '<Project Sdk="Microsoft.NET.Sdk">' +
             '<Import Project="{0}" />'.format(os.path.relpath(version.propsfile, os.path.dirname(version.projfile))) +
             '<PropertyGroup>' +
-            '<VersionPrefix>{0}</VersionPrefix>'.format(version.prefix) +
+            '<Version>{0}</Version>'.format(version.package_version) +
             '</PropertyGroup>' +
             '</Project>\' > $@\n')
 
@@ -238,9 +246,16 @@ def main(args):
             '-v $(abspath recipes):/io/recipes ' +
             '-v $(abspath $(dir $<)):/io/input ' +
             '-v $(abspath $(dir $@)):/io/output ' +
-            '{0} sh -x -e /io/recipes/{1} "{2}"\n'.format('microsoft/dotnet:latest', 'pack', version.suffix if version.suffix is not None else ''))
+            '{0} sh -x -e /io/recipes/{1} {2}\n'.format('microsoft/dotnet:1.1-sdk', 'pack', os.path.relpath(version.projfile, version.builddir)))
 
-  print('prepared', MAKEFILE, 'to make', version.pkgfile)
+    f.write('\n')
+    f.write('test: {0}\n'.format(version.pkgfile))
+    f.write('\t{0} run --rm '.format(DOCKER) +
+            '-v $(abspath recipes):/io/recipes ' +
+            '-v $(abspath $(dir $<)):/io/packages ' +
+            '{0} sh -x -e /io/recipes/{1} "{2}"\n'.format('microsoft/dotnet:1.1-sdk', 'test', version.package_version))
+
+  print('prepared', MAKEFILE, 'to make', version.pkgfile, 'for libsodium', version.libsodium_version)
   return 0
 
 if __name__ == '__main__':

--- a/packaging/dotnet-core/recipes/pack
+++ b/packaging/dotnet-core/recipes/pack
@@ -1,5 +1,5 @@
 cp -r /io/input ~/build
 cd ~/build
-dotnet restore
-dotnet pack --version-suffix "$1"
+dotnet restore $1
+dotnet pack $1
 cp *.nupkg /io/output

--- a/packaging/dotnet-core/recipes/test
+++ b/packaging/dotnet-core/recipes/test
@@ -1,0 +1,27 @@
+TEST_PROGRAM='using System;
+using System.Runtime.InteropServices;
+
+static class Program
+{
+    [DllImport("libsodium")]
+    static extern int sodium_init();
+
+    static int Main()
+    {
+        int error = sodium_init();
+        Console.WriteLine(error == 0
+            ? "ok"
+            : "error: sodium_init() returned {0}", error);
+        return error == 0 ? 0 : 1;
+    }
+}
+'
+
+dotnet --info
+cd ~
+dotnet new console --name Test
+cd Test
+echo "$TEST_PROGRAM" > Program.cs
+dotnet add package libsodium --version $1 --source /io/packages
+dotnet restore
+dotnet run


### PR DESCRIPTION
* Updates scripts to support package version numbers with four parts
* Adds `make test` to perform a quick test on the generated package
* Removes support for alpine.3-x64
* Adds support for fedora.26-x64
