### PR TITLE
Update packaging for .NET Core

### DIFF
--- a/packaging/dotnet-core/prepare.py
+++ b/packaging/dotnet-core/prepare.py
@@ -17,8 +17,6 @@ MACOS = [
   # --------------------- ----------------- #
   # Runtime ID            Codename          #
   # --------------------- ----------------- #
-  ( 'osx.10.10-x64',      'yosemite'        ),
-  ( 'osx.10.11-x64',      'el_capitan'      ),
   ( 'osx.10.12-x64',      'sierra'          ),
   # --------------------- ----------------- #
 ]
@@ -27,15 +25,7 @@ LINUX = [
   # --------------------- ----------------- #
   # Runtime ID            Docker Image      #
   # --------------------- ----------------- #
-  ( 'centos.7-x64',       'centos:7.1.1503' ),
-  ( 'debian.8-x64',       'debian:8.2'      ),
-  ( 'fedora.24-x64',      'fedora:24'       ),
-  ( 'fedora.25-x64',      'fedora:25'       ),
-  ( 'fedora.26-x64',      'fedora:26'       ),
-  ( 'opensuse.42.1-x64',  'opensuse:42.1'   ),
-  ( 'ubuntu.14.04-x64',   'ubuntu:trusty'   ),
-  ( 'ubuntu.16.04-x64',   'ubuntu:xenial'   ),
-  ( 'ubuntu.16.10-x64',   'ubuntu:yakkety'  ),
+  ( 'linux-x64',          'debian:stretch'  ),
   # --------------------- ----------------- #
 ]
 

--- a/packaging/dotnet-core/recipes/linux-x64
+++ b/packaging/dotnet-core/recipes/linux-x64
@@ -1,0 +1,4 @@
+apt-get update
+apt-get install -y --no-install-recommends build-essential
+
+. $(dirname $0)/build


### PR DESCRIPTION
* Removes support for osx.10.10-x64, osx.10.11-x64, centos.7-x64, fedora.24-x64,  opensuse.42.1-x64, and ubuntu.16.10-x64 as they are no longer supported
* Replaces support for debian.8-x64, fedora.25-x64, fedora.26-x64, ubuntu.14.04-x64, and ubuntu.16.04-x64 with support for any Linux x64 distribution that has a sufficiently recent GLIBC

(See: [.NET Core 2.0 - Supported OS versions](https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0-supported-os.md))

The presence of the .NET Framework 4.6 files in the package added by @BurningEnlightenment  still cause problems with the current .NET Core 2.0 pre-release. This pull request does not fix that yet. If the problems are still present with the final .NET Core 2.0 version, we may have to remove .NET Framework support.

@jedisct1: It would be awesome if you could include the NuGet package in your regular release dance, so that new libsodium versions are timely available (even when there are no changes to the packaging scripts). Command for the next pre-release: `python3 prepare.py 1.0.13-preview-01 && make`. (Please pull updated docker images first.)