### PR TITLE
Update packaging for .NET Core

### DIFF
--- a/packaging/dotnet-core/libsodium.props
+++ b/packaging/dotnet-core/libsodium.props
@@ -23,6 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="LICENSE" PackagePath="" />
     <Content Include="AUTHORS" PackagePath="" />
     <Content Include="ChangeLog" PackagePath="" />


### PR DESCRIPTION
This adds support for new-style .NET Framework projects.

@jedisct1 - Please publish libsodium 1.0.13-preview-01 to nuget.org with this change.