### PR TITLE
[freebsd] use arc4random on FreeBSD

### DIFF
--- a/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c
+++ b/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c
@@ -55,7 +55,7 @@ BOOLEAN NTAPI RtlGenRandom(PVOID RandomBuffer, ULONG RandomBufferLength);
 # pragma comment(lib, "advapi32.lib")
 #endif
 
-#if defined(__OpenBSD__) || defined(__CloudABI__)
+#if defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__CloudABI__)
 # define HAVE_SAFE_ARC4RANDOM 1
 #endif
 
@@ -88,7 +88,7 @@ randombytes_sysrandom_close(void)
     return 0;
 }
 
-#else /* __OpenBSD__ */
+#else /* __OpenBSD__, __FreeBSD__, __CloudABI__ */
 
 typedef struct SysRandom_ {
     int random_data_source_fd;
@@ -364,7 +364,7 @@ randombytes_sysrandom(void)
     return r;
 }
 
-#endif /* __OpenBSD__ */
+#endif /* __OpenBSD__, __FreeBSD__, __CloudABI__ */
 
 static const char *
 randombytes_sysrandom_implementation_name(void)


### PR DESCRIPTION
This would help while running a process in a chroot without /dev/random
on FreeBSD, just like on OpenBSD
See #625

Using https://gist.github.com/chantra/910305a456cbcf2a7fc8aeaa259036fe
and assuming using libsodium-stable

https://github.com/jedisct1/libsodium/commit/5d484e6cb2ea1f2d4d052e31627be6ee2e2477c3

before we would get:
```
root@freebsd-512mb-sfo2-01:~ # env
LD_PRELOAD=/tmp/lsodium/lib/libsodium.so ./sodium_init
sodium_set_misuse_handler
Misused handler!
```

after:
```
root@freebsd-512mb-sfo2-01:~ # env
LD_PRELOAD=/tmp/lsodium/lib/libsodium.so ./sodium_init
sodium_set_misuse_handler
Hello world,
```