### PR TITLE
Add crypto_pwhash_BYTES const

### DIFF
--- a/src/libsodium/crypto_pwhash/argon2/pwhash_argon2i.c
+++ b/src/libsodium/crypto_pwhash/argon2/pwhash_argon2i.c
@@ -25,6 +25,12 @@ crypto_pwhash_argon2i_alg_argon2i13(void)
 }
 
 size_t
+crypto_pwhash_argon2i_bytes(void)
+{
+    return crypto_pwhash_argon2i_BYTES;
+}
+
+size_t
 crypto_pwhash_argon2i_bytes_min(void)
 {
     COMPILER_ASSERT(crypto_pwhash_argon2i_BYTES_MIN >= ARGON2_MIN_OUTLEN);

--- a/src/libsodium/crypto_pwhash/argon2/pwhash_argon2id.c
+++ b/src/libsodium/crypto_pwhash/argon2/pwhash_argon2id.c
@@ -21,6 +21,12 @@ crypto_pwhash_argon2id_alg_argon2id13(void)
 }
 
 size_t
+crypto_pwhash_argon2id_bytes(void)
+{
+    return crypto_pwhash_argon2id_BYTES;
+}
+
+size_t
 crypto_pwhash_argon2id_bytes_min(void)
 {
     COMPILER_ASSERT(crypto_pwhash_argon2id_BYTES_MIN >= ARGON2_MIN_OUTLEN);

--- a/src/libsodium/crypto_pwhash/crypto_pwhash.c
+++ b/src/libsodium/crypto_pwhash/crypto_pwhash.c
@@ -24,6 +24,12 @@ crypto_pwhash_alg_default(void)
 }
 
 size_t
+crypto_pwhash_bytes(void)
+{
+    return crypto_pwhash_BYTES;
+}
+
+size_t
 crypto_pwhash_bytes_min(void)
 {
     return crypto_pwhash_BYTES_MIN;

--- a/src/libsodium/include/sodium/crypto_pwhash.h
+++ b/src/libsodium/include/sodium/crypto_pwhash.h
@@ -26,6 +26,10 @@ int crypto_pwhash_alg_argon2id13(void);
 SODIUM_EXPORT
 int crypto_pwhash_alg_default(void);
 
+#define crypto_pwhash_BYTES crypto_pwhash_argon2id_BYTES
+SODIUM_EXPORT
+size_t crypto_pwhash_bytes(void);
+
 #define crypto_pwhash_BYTES_MIN crypto_pwhash_argon2id_BYTES_MIN
 SODIUM_EXPORT
 size_t crypto_pwhash_bytes_min(void);

--- a/src/libsodium/include/sodium/crypto_pwhash_argon2i.h
+++ b/src/libsodium/include/sodium/crypto_pwhash_argon2i.h
@@ -18,6 +18,10 @@ extern "C" {
 SODIUM_EXPORT
 int crypto_pwhash_argon2i_alg_argon2i13(void);
 
+#define crypto_pwhash_argon2i_BYTES 32U
+SODIUM_EXPORT
+size_t crypto_pwhash_argon2i_bytes(void);
+
 #define crypto_pwhash_argon2i_BYTES_MIN 16U
 SODIUM_EXPORT
 size_t crypto_pwhash_argon2i_bytes_min(void);

--- a/src/libsodium/include/sodium/crypto_pwhash_argon2id.h
+++ b/src/libsodium/include/sodium/crypto_pwhash_argon2id.h
@@ -18,6 +18,10 @@ extern "C" {
 SODIUM_EXPORT
 int crypto_pwhash_argon2id_alg_argon2id13(void);
 
+#define crypto_pwhash_argon2id_BYTES 32U
+SODIUM_EXPORT
+size_t crypto_pwhash_argon2id_bytes(void);
+
 #define crypto_pwhash_argon2id_BYTES_MIN 16U
 SODIUM_EXPORT
 size_t crypto_pwhash_argon2id_bytes_min(void);

--- a/test/default/pwhash_argon2i.c
+++ b/test/default/pwhash_argon2i.c
@@ -396,6 +396,8 @@ main(void)
     tv3();
     str_tests();
 
+    assert(crypto_pwhash_argon2i_bytes() > 0U);
+    assert(crypto_pwhash_argon2i_bytes() < crypto_pwhash_argon2i_bytes_max());
     assert(crypto_pwhash_argon2i_bytes_min() > 0U);
     assert(crypto_pwhash_argon2i_bytes_max() > crypto_pwhash_argon2i_bytes_min());
     assert(crypto_pwhash_argon2i_passwd_max() > crypto_pwhash_argon2i_passwd_min());
@@ -414,6 +416,7 @@ main(void)
     assert(crypto_pwhash_argon2i_opslimit_sensitive() > 0U);
     assert(crypto_pwhash_argon2i_memlimit_sensitive() > 0U);
 
+    assert(crypto_pwhash_argon2i_bytes() == crypto_pwhash_argon2i_BYTES);
     assert(crypto_pwhash_argon2i_bytes_min() == crypto_pwhash_argon2i_BYTES_MIN);
     assert(crypto_pwhash_argon2i_bytes_max() == crypto_pwhash_argon2i_BYTES_MAX);
     assert(crypto_pwhash_argon2i_passwd_min() == crypto_pwhash_argon2i_PASSWD_MIN);

--- a/test/default/pwhash_argon2id.c
+++ b/test/default/pwhash_argon2id.c
@@ -396,6 +396,8 @@ main(void)
     tv3();
     str_tests();
 
+    assert(crypto_pwhash_bytes() > 0U);
+    assert(crypto_pwhash_bytes() < crypto_pwhash_bytes_max());
     assert(crypto_pwhash_bytes_min() > 0U);
     assert(crypto_pwhash_bytes_max() > crypto_pwhash_bytes_min());
     assert(crypto_pwhash_passwd_max() > crypto_pwhash_passwd_min());
@@ -415,6 +417,7 @@ main(void)
     assert(crypto_pwhash_memlimit_sensitive() > 0U);
     assert(strcmp(crypto_pwhash_primitive(), "argon2i") == 0);
 
+    assert(crypto_pwhash_bytes() == crypto_pwhash_BYTES);
     assert(crypto_pwhash_bytes_min() == crypto_pwhash_BYTES_MIN);
     assert(crypto_pwhash_bytes_max() == crypto_pwhash_BYTES_MAX);
     assert(crypto_pwhash_passwd_min() == crypto_pwhash_PASSWD_MIN);
@@ -439,6 +442,7 @@ main(void)
     assert(crypto_pwhash_memlimit_sensitive() ==
            crypto_pwhash_MEMLIMIT_SENSITIVE);
 
+    assert(crypto_pwhash_argon2id_bytes() == crypto_pwhash_bytes());
     assert(crypto_pwhash_argon2id_bytes_min() == crypto_pwhash_bytes_min());
     assert(crypto_pwhash_argon2id_bytes_max() == crypto_pwhash_bytes_max());
     assert(crypto_pwhash_argon2id_passwd_min() == crypto_pwhash_passwd_min());


### PR DESCRIPTION
I think it would be good to have a `crypto_pwhash_BYTES` like there is a `crypto_generichash_BYTES`. I know that the "easy path" should be to use `crypto_pwhash_str`, but I think it would be good for user experience to have the bytes for symmetry with other APIs, and it doesn't add much maintenance overhead.