### PR TITLE
[CMAKE] Fix static library detection on unix

### DIFF
--- a/contrib/Findsodium.cmake
+++ b/contrib/Findsodium.cmake
@@ -55,23 +55,35 @@ if (UNIX)
     endif()
 
     if(sodium_USE_STATIC_LIBS)
+        foreach(_libname ${sodium_PKG_STATIC_LIBRARIES})
+            if (NOT _libname MATCHES "^lib.*\\.a$") # ignore strings already ending with .a
+                list(INSERT sodium_PKG_STATIC_LIBRARIES 0 "lib${_libname}.a")
+            endif()
+        endforeach()
+        list(REMOVE_DUPLICATES sodium_PKG_STATIC_LIBRARIES)
+
         # if pkgconfig for libsodium doesn't provide
         # static lib info, then override PKG_STATIC here..
-        if (NOT DEFINED sodium_PKG_STATIC_LIBRARIES)
+        if (sodium_PKG_STATIC_LIBRARIES STREQUAL "")
             set(sodium_PKG_STATIC_LIBRARIES libsodium.a)
         endif()
+
         set(XPREFIX sodium_PKG_STATIC)
     else()
+        if (sodium_PKG_LIBRARIES STREQUAL "")
+            set(sodium_PKG_LIBRARIES sodium)
+        endif()
+
         set(XPREFIX sodium_PKG)
     endif()
 
     find_path(sodium_INCLUDE_DIR sodium.h
         HINTS ${${XPREFIX}_INCLUDE_DIRS}
     )
-    find_library(sodium_LIBRARY_DEBUG NAMES ${${XPREFIX}_LIBRARIES} sodium
+    find_library(sodium_LIBRARY_DEBUG NAMES ${${XPREFIX}_LIBRARIES}
         HINTS ${${XPREFIX}_LIBRARY_DIRS}
     )
-    find_library(sodium_LIBRARY_RELEASE NAMES ${${XPREFIX}_LIBRARIES} sodium
+    find_library(sodium_LIBRARY_RELEASE NAMES ${${XPREFIX}_LIBRARIES}
         HINTS ${${XPREFIX}_LIBRARY_DIRS}
     )
 


### PR DESCRIPTION
Manually prepend `lib` and append `.a` to the static library names provided by the cmake pkg-config cmake module. This is necessary because the `find_library()` function always prefers the shared object file if the library name is "unqualified" and unfortunately the cmake pkg-config module seems to provide only "unqualified" library names through `*_PKG_STATIC_LIBIRARIES` (which makes this part of the cmake pkg config module rather useless for most cases 😒).

After inspecting the pkg config module source I also found out that the pkg config variables are _always_ set and therefore never undefined which is why I replaced the not defined case.

@mellery451 and @nibua-r can you test this, please?
@jedisct1 please do not merge yet, thanks :wink:

/xref #621
