### PR TITLE
Updates for latest emscripten

### DIFF
--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -9,7 +9,7 @@ export TOTAL_MEMORY_SUMO=83886080
 export TOTAL_MEMORY_TESTS=167772160
 export LDFLAGS="-s RESERVED_FUNCTION_POINTERS=8"
 export LDFLAGS="${LDFLAGS} -s SINGLE_FILE=1"
-export LDFLAGS="${LDFLAGS} -s NO_DYNAMIC_EXECUTION=1 -s ASSERTIONS=0"
+export LDFLAGS="${LDFLAGS} -s ASSERTIONS=0"
 export LDFLAGS="${LDFLAGS} -s AGGRESSIVE_VARIABLE_ELIMINATION=1 -s ALIASING_FUNCTION_POINTERS=1"
 export LDFLAGS="${LDFLAGS} -s FUNCTION_POINTER_ALIGNMENT=1 -s DISABLE_EXCEPTION_CATCHING=1"
 export LDFLAGS="${LDFLAGS} -s ELIMINATE_DUPLICATE_FUNCTIONS=1"
@@ -72,11 +72,11 @@ if [ "$DIST" = yes ]; then
   emccLibsodium () {
     outFile="${1}"
     shift
-    emcc "$CFLAGS" --llvm-lto 1 $CPPFLAGS $LDFLAGS $JS_EXPORTS_FLAGS ${@} \
+    emcc "$CFLAGS" --closure 1 --llvm-lto 1 $CPPFLAGS $LDFLAGS $JS_EXPORTS_FLAGS ${@} \
       "${PREFIX}/lib/libsodium.a" -o "${outFile}" || exit 1
   }
   emmake make $MAKE_FLAGS install || exit 1
-  emccLibsodium "${PREFIX}/lib/libsodium.asm.tmp.js" -Oz -s RUNNING_JS_OPTS=1 -s NO_EXIT_RUNTIME=1
+  emccLibsodium "${PREFIX}/lib/libsodium.asm.tmp.js" -Oz -s RUNNING_JS_OPTS=1
   emccLibsodium "${PREFIX}/lib/libsodium.wasm.tmp.js" -O3 -s WASM=1
 
   cat > "${PREFIX}/lib/libsodium.js" <<- EOM

--- a/src/libsodium/randombytes/randombytes.c
+++ b/src/libsodium/randombytes/randombytes.c
@@ -107,7 +107,7 @@ randombytes_stir(void)
                 try {
                     var crypto = require('crypto');
                     var randomValueNodeJS = function() {
-                        var buf = crypto.randomBytes(4);
+                        var buf = crypto['randomBytes'](4);
                         return (buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3]) >>> 0;
                     };
                     randomValueNodeJS();


### PR DESCRIPTION
As of the latest version of emscripten available via the sdk (1.37.27):

* `-s NO_DYNAMIC_EXECUTION=1` is basically a no-op (https://github.com/kripken/emscripten/issues/5911)

* `--closure 1` can be safely enabled for better minification due to the above

* `-s NO_EXIT_RUNTIME=1` is a no-op (https://github.com/kripken/emscripten/pull/5878)