### PR TITLE
Fix: undefined SIZE_MAX when building android

### DIFF
--- a/src/libsodium/include/sodium/export.h
+++ b/src/libsodium/include/sodium/export.h
@@ -2,6 +2,8 @@
 #ifndef sodium_export_H
 #define sodium_export_H
 
+#include <limits.h>
+
 #if !defined(__clang__) && !defined(__GNUC__)
 # ifdef __attribute__
 #  undef __attribute__


### PR DESCRIPTION
Fix: undefined SIZE_MAX when building android