### PR TITLE
Add spectre v2 migitations for GCC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,9 @@ AC_CHECK_DEFINE([_FORTIFY_SOURCE], [], [
 AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],
   [CFLAGS="$CFLAGS -fvisibility=hidden"])
 
+AX_CHECK_COMPILE_FLAG([-mfunction-return=thunk -mindirect-branch=thunk],
+  [CFLAGS="$CFLAGS -mfunction-return=thunk -mindirect-branch=thunk"])
+
 AS_CASE([$host_os], [cygwin*|mingw*|msys|pw32*|cegcc*], [ ], [
   AX_CHECK_COMPILE_FLAG([-fPIC], [CFLAGS="$CFLAGS -fPIC"])
 ])


### PR DESCRIPTION
GCC 7.3 has support for retpoline. I see that the previous patch was reverted due to the use of -mretpoline. retpoline support is enabled via -mfunction-return=thunk and -mindirect-branch=thunk, in GCC. 