### PR TITLE
Adding option to enable a full build

### DIFF
--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -45,12 +45,13 @@ env - PATH="$PATH" \
     "$MAKE_TOOLCHAIN" --force --api="$NDK_API_VERSION_COMPAT" \
     --arch="$ARCH" --install-dir="$TOOLCHAIN_DIR" || exit 1
 
-if [ -z "$LIBSODIUM_ANDROID_CONFIGURE_FLAGS" ]; then
-  export LIBSODIUM_ANDROID_CONFIGURE_FLAGS="--disable-soname-versions --enable-minimal"
+if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
 fi
 
 ./configure \
-    ${LIBSODIUM_ANDROID_CONFIGURE_FLAGS} \
+    --disable-soname-versions \
+    ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
     --host="${HOST_COMPILER}" \
     --prefix="${PREFIX}" \
     --with-sysroot="${TOOLCHAIN_DIR}/sysroot" || exit 1
@@ -65,7 +66,8 @@ if [ "$NDK_PLATFORM" != "$NDK_PLATFORM_COMPAT" ]; then
       --arch="$ARCH" --install-dir="$TOOLCHAIN_DIR" || exit 1
 
   ./configure \
-      ${LIBSODIUM_ANDROID_CONFIGURE_FLAGS} \
+      --disable-soname-versions \
+      ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
       --host="${HOST_COMPILER}" \
       --prefix="${PREFIX}" \
       --with-sysroot="${TOOLCHAIN_DIR}/sysroot" || exit 1

--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -46,9 +46,9 @@ env - PATH="$PATH" \
     --arch="$ARCH" --install-dir="$TOOLCHAIN_DIR" || exit 1
 
 if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
-  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
-else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+else
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
 fi
 
 ./configure \

--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -45,9 +45,12 @@ env - PATH="$PATH" \
     "$MAKE_TOOLCHAIN" --force --api="$NDK_API_VERSION_COMPAT" \
     --arch="$ARCH" --install-dir="$TOOLCHAIN_DIR" || exit 1
 
+if [ -z "$LIBSODIUM_ANDROID_CONFIGURE_FLAGS" ]; then
+  export LIBSODIUM_ANDROID_CONFIGURE_FLAGS="--disable-soname-versions --enable-minimal"
+fi
+
 ./configure \
-    --disable-soname-versions \
-    --enable-minimal \
+    ${LIBSODIUM_ANDROID_CONFIGURE_FLAGS} \
     --host="${HOST_COMPILER}" \
     --prefix="${PREFIX}" \
     --with-sysroot="${TOOLCHAIN_DIR}/sysroot" || exit 1
@@ -62,8 +65,7 @@ if [ "$NDK_PLATFORM" != "$NDK_PLATFORM_COMPAT" ]; then
       --arch="$ARCH" --install-dir="$TOOLCHAIN_DIR" || exit 1
 
   ./configure \
-      --disable-soname-versions \
-      --enable-minimal \
+      ${LIBSODIUM_ANDROID_CONFIGURE_FLAGS} \
       --host="${HOST_COMPILER}" \
       --prefix="${PREFIX}" \
       --with-sysroot="${TOOLCHAIN_DIR}/sysroot" || exit 1

--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -45,7 +45,9 @@ env - PATH="$PATH" \
     "$MAKE_TOOLCHAIN" --force --api="$NDK_API_VERSION_COMPAT" \
     --arch="$ARCH" --install-dir="$TOOLCHAIN_DIR" || exit 1
 
-if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
+else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
 fi
 

--- a/dist-build/ios.sh
+++ b/dist-build/ios.sh
@@ -33,7 +33,9 @@ export LDFLAGS="-arch i386 -isysroot ${SDK} -mios-simulator-version-min=${IOS_SI
 
 make distclean > /dev/null
 
-if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
+else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
 fi
 

--- a/dist-build/ios.sh
+++ b/dist-build/ios.sh
@@ -34,9 +34,9 @@ export LDFLAGS="-arch i386 -isysroot ${SDK} -mios-simulator-version-min=${IOS_SI
 make distclean > /dev/null
 
 if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
-  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
-else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+else
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
 fi
 
 ./configure --host=i686-apple-darwin10 \

--- a/dist-build/ios.sh
+++ b/dist-build/ios.sh
@@ -33,9 +33,13 @@ export LDFLAGS="-arch i386 -isysroot ${SDK} -mios-simulator-version-min=${IOS_SI
 
 make distclean > /dev/null
 
+if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+fi
+
 ./configure --host=i686-apple-darwin10 \
             --disable-shared \
-            --enable-minimal \
+            ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --prefix="$SIMULATOR32_PREFIX" || exit 1
 
 make -j3 install || exit 1
@@ -48,7 +52,7 @@ make distclean > /dev/null
 
 ./configure --host=x86_64-apple-darwin10 \
             --disable-shared \
-            --enable-minimal \
+            ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --prefix="$SIMULATOR64_PREFIX"
 
 make -j3 install || exit 1
@@ -66,7 +70,7 @@ make distclean > /dev/null
 
 ./configure --host=arm-apple-darwin10 \
             --disable-shared \
-            --enable-minimal \
+            ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --prefix="$IOS32_PREFIX" || exit 1
 
 make -j3 install || exit 1
@@ -79,7 +83,7 @@ make distclean > /dev/null
 
 ./configure --host=arm-apple-darwin10 \
             --disable-shared \
-            --enable-minimal \
+            ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --prefix="$IOS32s_PREFIX" || exit 1
 
 make -j3 install || exit 1
@@ -92,7 +96,7 @@ make distclean > /dev/null
 
 ./configure --host=arm-apple-darwin10 \
             --disable-shared \
-            --enable-minimal \
+            ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --prefix="$IOS64_PREFIX" || exit 1
 
 make -j3 install || exit 1

--- a/dist-build/nativeclient-pnacl.sh
+++ b/dist-build/nativeclient-pnacl.sh
@@ -20,11 +20,10 @@ mkdir -p $PREFIX || exit 1
 make distclean > /dev/null
 
 if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
-  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
-else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+else
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
 fi
-
 
 ./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --host=nacl \

--- a/dist-build/nativeclient-pnacl.sh
+++ b/dist-build/nativeclient-pnacl.sh
@@ -19,7 +19,11 @@ mkdir -p $PREFIX || exit 1
 
 make distclean > /dev/null
 
-./configure --enable-minimal \
+if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+fi
+
+./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --host=nacl \
             --disable-ssp --without-pthreads \
             --prefix="$PREFIX" || exit 1

--- a/dist-build/nativeclient-pnacl.sh
+++ b/dist-build/nativeclient-pnacl.sh
@@ -19,9 +19,12 @@ mkdir -p $PREFIX || exit 1
 
 make distclean > /dev/null
 
-if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
+else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
 fi
+
 
 ./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --host=nacl \

--- a/dist-build/nativeclient-x86.sh
+++ b/dist-build/nativeclient-x86.sh
@@ -12,10 +12,11 @@ mkdir -p $PREFIX || exit 1
 make distclean > /dev/null
 
 if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
-  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
-else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+else
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
 fi
+
 
 ./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --host=i686-nacl \

--- a/dist-build/nativeclient-x86.sh
+++ b/dist-build/nativeclient-x86.sh
@@ -11,7 +11,11 @@ mkdir -p $PREFIX || exit 1
 
 make distclean > /dev/null
 
-./configure --enable-minimal \
+if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+fi
+
+./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --host=i686-nacl \
             --disable-ssp --without-pthreads \
             --prefix="$PREFIX" || exit 1

--- a/dist-build/nativeclient-x86.sh
+++ b/dist-build/nativeclient-x86.sh
@@ -11,7 +11,9 @@ mkdir -p $PREFIX || exit 1
 
 make distclean > /dev/null
 
-if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
+else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
 fi
 

--- a/dist-build/nativeclient-x86_64.sh
+++ b/dist-build/nativeclient-x86_64.sh
@@ -11,7 +11,11 @@ mkdir -p $PREFIX || exit 1
 
 make distclean > /dev/null
 
-./configure --enable-minimal \
+if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+fi
+
+./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --host=x86_64-nacl \
             --disable-ssp --without-pthreads \
             --prefix="$PREFIX" || exit 1

--- a/dist-build/nativeclient-x86_64.sh
+++ b/dist-build/nativeclient-x86_64.sh
@@ -11,7 +11,9 @@ mkdir -p $PREFIX || exit 1
 
 make distclean > /dev/null
 
-if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
+else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
 fi
 

--- a/dist-build/nativeclient-x86_64.sh
+++ b/dist-build/nativeclient-x86_64.sh
@@ -12,9 +12,9 @@ mkdir -p $PREFIX || exit 1
 make distclean > /dev/null
 
 if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
-  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
-else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+else
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
 fi
 
 ./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \

--- a/dist-build/osx.sh
+++ b/dist-build/osx.sh
@@ -11,7 +11,11 @@ export LDFLAGS="-arch x86_64 -mmacosx-version-min=${OSX_VERSION_MIN} -march=${OS
 
 make distclean > /dev/null
 
-./configure --enable-minimal \
+if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+fi
+
+./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
             --prefix="$PREFIX" || exit 1
 
 make -j3 check && make -j3 install || exit 1

--- a/dist-build/osx.sh
+++ b/dist-build/osx.sh
@@ -12,9 +12,9 @@ export LDFLAGS="-arch x86_64 -mmacosx-version-min=${OSX_VERSION_MIN} -march=${OS
 make distclean > /dev/null
 
 if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
-  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
-else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
+else
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
 fi
 
 ./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \

--- a/dist-build/osx.sh
+++ b/dist-build/osx.sh
@@ -11,7 +11,9 @@ export LDFLAGS="-arch x86_64 -mmacosx-version-min=${OSX_VERSION_MIN} -march=${OS
 
 make distclean > /dev/null
 
-if [ -z "$LIBSODIUM_ENABLE_MINIMAL_FLAG" ]; then
+if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
+  export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
+else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
 fi
 


### PR DESCRIPTION
We are working on a solution to use scrypt in libsodium-jni.

I'm trying to work this out together with @joshjdevl.

I understand if this is not the correct solution but it's a suggestion from my side give us the option to build the full libsodium.