### PR TITLE
add crypto_scalarmult_ed25519_noclamp

### DIFF
--- a/src/libsodium/include/sodium/crypto_scalarmult_ed25519.h
+++ b/src/libsodium/include/sodium/crypto_scalarmult_ed25519.h
@@ -31,8 +31,24 @@ int crypto_scalarmult_ed25519(unsigned char *q, const unsigned char *n,
                               const unsigned char *p)
             __attribute__ ((warn_unused_result));
 
+/*
+ * NOTE: Do not use the result of this function directly.
+ *
+ * Hash the result with the public keys in order to compute a shared
+ * secret key: H(q || client_pk || server_pk)
+ *
+ * Or unless this is not an option, use the crypto_kx() API instead.
+ */
+SODIUM_EXPORT
+int crypto_scalarmult_ed25519_noclamp(unsigned char *q, const unsigned char *n,
+                              const unsigned char *p)
+            __attribute__ ((warn_unused_result));
+
 SODIUM_EXPORT
 int crypto_scalarmult_ed25519_base(unsigned char *q, const unsigned char *n);
+
+SODIUM_EXPORT
+int crypto_scalarmult_ed25519_base_noclamp(unsigned char *q, const unsigned char *n);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
`crypto_scalarmult_ed25519(q, n, p)` clamps the scalar `n` to a suitable
value for finding the point on the curve. This is limiting in scenarios
where the scalar multiplication should be done over unclamped scalars
such as field elements arising out of field arithmetic. An example of
such a use case is the Schnorr NIZK protocol from RFC8235.

