### PR TITLE
Change LDFLAGS to LIBSODIUM_LDFLAGS to resolve build issue on Mac

### DIFF
--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -7,19 +7,19 @@ export EXPORTED_RUNTIME_METHODS='["Pointer_stringify","getValue","setValue"]'
 export TOTAL_MEMORY=16777216
 export TOTAL_MEMORY_SUMO=83886080
 export TOTAL_MEMORY_TESTS=167772160
-export LDFLAGS="-s RESERVED_FUNCTION_POINTERS=8"
-export LDFLAGS="${LDFLAGS} -s SINGLE_FILE=1"
-export LDFLAGS="${LDFLAGS} -s ASSERTIONS=0"
-export LDFLAGS="${LDFLAGS} -s AGGRESSIVE_VARIABLE_ELIMINATION=1 -s ALIASING_FUNCTION_POINTERS=1"
-export LDFLAGS="${LDFLAGS} -s DISABLE_EXCEPTION_CATCHING=1"
-export LDFLAGS="${LDFLAGS} -s ELIMINATE_DUPLICATE_FUNCTIONS=1"
-export LDFLAGS_DIST="-s NO_FILESYSTEM=1"
+export LIBSODIUM_LDFLAGS="-s RESERVED_FUNCTION_POINTERS=8"
+export LIBSODIUM_LDFLAGS="${LIBSODIUM_LDFLAGS} -s SINGLE_FILE=1"
+export LIBSODIUM_LDFLAGS="${LIBSODIUM_LDFLAGS} -s ASSERTIONS=0"
+export LIBSODIUM_LDFLAGS="${LIBSODIUM_LDFLAGS} -s AGGRESSIVE_VARIABLE_ELIMINATION=1 -s ALIASING_FUNCTION_POINTERS=1"
+export LIBSODIUM_LDFLAGS="${LIBSODIUM_LDFLAGS} -s DISABLE_EXCEPTION_CATCHING=1"
+export LIBSODIUM_LDFLAGS="${LIBSODIUM_LDFLAGS} -s ELIMINATE_DUPLICATE_FUNCTIONS=1"
+export LIBSODIUM_LDFLAGS_DIST="-s NO_FILESYSTEM=1"
 export CFLAGS="-Os"
 
 echo
 if [ "x$1" = "x--standard" ]; then
   export EXPORTED_FUNCTIONS="$EXPORTED_FUNCTIONS_STANDARD"
-  export LDFLAGS="${LDFLAGS} ${LDFLAGS_DIST} -s TOTAL_MEMORY=${TOTAL_MEMORY}"
+  export LIBSODIUM_LDFLAGS="${LIBSODIUM_LDFLAGS} ${LIBSODIUM_LDFLAGS_DIST} -s TOTAL_MEMORY=${TOTAL_MEMORY}"
   export PREFIX="$(pwd)/libsodium-js"
   export DONE_FILE="$(pwd)/js.done"
   export CONFIG_EXTRA="--enable-minimal"
@@ -27,14 +27,14 @@ if [ "x$1" = "x--standard" ]; then
   echo "Building a standard distribution in [${PREFIX}]"
 elif [ "x$1" = "x--sumo" ]; then
   export EXPORTED_FUNCTIONS="$EXPORTED_FUNCTIONS_SUMO"
-  export LDFLAGS="${LDFLAGS} ${LDFLAGS_DIST} -s TOTAL_MEMORY=${TOTAL_MEMORY_SUMO}"
+  export LIBSODIUM_LDFLAGS="${LIBSODIUM_LDFLAGS} ${LIBSODIUM_LDFLAGS_DIST} -s TOTAL_MEMORY=${TOTAL_MEMORY_SUMO}"
   export PREFIX="$(pwd)/libsodium-js-sumo"
   export DONE_FILE="$(pwd)/js-sumo.done"
   export DIST='yes'
   echo "Building a sumo distribution in [${PREFIX}]"
 elif [ "x$1" = "x--browser-tests" ]; then
   export EXPORTED_FUNCTIONS="$EXPORTED_FUNCTIONS_SUMO"
-  export LDFLAGS="${LDFLAGS} -s TOTAL_MEMORY=${TOTAL_MEMORY_TESTS}"
+  export LIBSODIUM_LDFLAGS="${LIBSODIUM_LDFLAGS} -s TOTAL_MEMORY=${TOTAL_MEMORY_TESTS}"
   export PREFIX="$(pwd)/libsodium-js-tests"
   export DONE_FILE="$(pwd)/js-tests-browser.done"
   export BROWSER_TESTS='yes'
@@ -44,7 +44,7 @@ elif [ "x$1" = "x--tests" ]; then
   echo "Building for testing"
   export EXPORTED_FUNCTIONS="$EXPORTED_FUNCTIONS_SUMO"
   export CPPFLAGS="${CPPFLAGS} -DBENCHMARKS -DITERATIONS=10"
-  export LDFLAGS="${LDFLAGS} -s TOTAL_MEMORY=${TOTAL_MEMORY_TESTS}"
+  export LIBSODIUM_LDFLAGS="${LIBSODIUM_LDFLAGS} -s TOTAL_MEMORY=${TOTAL_MEMORY_TESTS}"
   export PREFIX="$(pwd)/libsodium-js-tests"
   export DONE_FILE="$(pwd)/js-tests.done"
   export DIST='no'
@@ -72,7 +72,7 @@ if [ "$DIST" = yes ]; then
   emccLibsodium () {
     outFile="${1}"
     shift
-    emcc "$CFLAGS" --llvm-lto 1 $CPPFLAGS $LDFLAGS $JS_EXPORTS_FLAGS ${@} \
+    emcc "$CFLAGS" --llvm-lto 1 $CPPFLAGS $LIBSODIUM_LDFLAGS $JS_EXPORTS_FLAGS ${@} \
       "${PREFIX}/lib/libsodium.a" -o "${outFile}" || exit 1
   }
   emmake make $MAKE_FLAGS install || exit 1


### PR DESCRIPTION
On macOS 10.13.4, trying to build libsodium.js results in the following error for me: 

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -Os  -Wl,-search_paths_first -Wl,-headerpad_max_install_names -s RESERVED_FUNCTION_POINTERS=8 -s SINGLE_FILE=1 -s ASSERTIONS=0 -s AGGRESSIVE_VARIABLE_ELIMINATION=1 -s ALIASING_FUNCTION_POINTERS=1 -s DISABLE_EXCEPTION_CATCHING=1 -s ELIMINATE_DUPLICATE_FUNCTIONS=1 -s NO_FILESYSTEM=1 -s TOTAL_MEMORY=83886080  CMakeFiles/cmTC_03fc1.dir/testCCompiler.c.o  -o cmTC_03fc1 
    clang: error: no such file or directory: 'RESERVED_FUNCTION_POINTERS=8'
    clang: error: no such file or directory: 'SINGLE_FILE=1'
    clang: error: no such file or directory: 'ASSERTIONS=0'
    clang: error: no such file or directory: 'AGGRESSIVE_VARIABLE_ELIMINATION=1'
    clang: error: no such file or directory: 'ALIASING_FUNCTION_POINTERS=1'
    clang: error: no such file or directory: 'DISABLE_EXCEPTION_CATCHING=1'
    clang: error: no such file or directory: 'ELIMINATE_DUPLICATE_FUNCTIONS=1'
    clang: error: no such file or directory: 'NO_FILESYSTEM=1'
    clang: error: no such file or directory: 'TOTAL_MEMORY=83886080'
    make[2]: *** [cmTC_03fc1] Error 1
```

It appears that `$LDFLAGS` is implicitly picked up by Xcode's cc, which causes the build to fail. Simply renaming this environment variable fixes the issue.