### PR TITLE
Fix CPU feature detection crash on VS 2010 32-bit /O2

### DIFF
--- a/src/libsodium/sodium/runtime.c
+++ b/src/libsodium/sodium/runtime.c
@@ -109,9 +109,6 @@ _cpuid(unsigned int cpu_info[4U], const unsigned int cpu_info_type)
 #endif
 }
 
-#ifdef _MSC_VER
-#pragma optimize( "", off )
-#endif
 static int
 _sodium_runtime_intel_cpu_features(CPUFeatures * const cpu_features)
 {
@@ -157,9 +154,15 @@ _sodium_runtime_intel_cpu_features(CPUFeatures * const cpu_features)
         xcr0 = (uint32_t) _xgetbv(0);
 # elif defined(_MSC_VER) && defined(_M_IX86)
         __asm {
+			push eax
+			push ecx
+			push edx
             xor ecx, ecx
             _asm _emit 0x0f _asm _emit 0x01 _asm _emit 0xd0
             mov xcr0, eax
+			pop eax
+			pop ecx
+			pop edx
         }
 # elif defined(HAVE_AVX_ASM)
         __asm__ __volatile__(".byte 0x0f, 0x01, 0xd0" /* XGETBV */
@@ -209,9 +212,6 @@ _sodium_runtime_intel_cpu_features(CPUFeatures * const cpu_features)
 
     return 0;
 }
-#ifdef _MSC_VER
-#pragma optimize( "", on )
-#endif
 
 int
 _sodium_runtime_get_cpu_features(void)

--- a/src/libsodium/sodium/runtime.c
+++ b/src/libsodium/sodium/runtime.c
@@ -109,6 +109,9 @@ _cpuid(unsigned int cpu_info[4U], const unsigned int cpu_info_type)
 #endif
 }
 
+#ifdef _MSC_VER
+#pragma optimize( "", off )
+#endif
 static int
 _sodium_runtime_intel_cpu_features(CPUFeatures * const cpu_features)
 {
@@ -206,6 +209,9 @@ _sodium_runtime_intel_cpu_features(CPUFeatures * const cpu_features)
 
     return 0;
 }
+#ifdef _MSC_VER
+#pragma optimize( "", on )
+#endif
 
 int
 _sodium_runtime_get_cpu_features(void)


### PR DESCRIPTION
This is a crash in a very specific build configuration, where the optimizer put the cpu_features pointer in eax, and then eax got blown away by the feature detection asm. Turning off optimizations for this function solved the problem.