### PR TITLE
Fix for emscripten breaking change

### DIFF
--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -76,7 +76,7 @@ if [ "$DIST" = yes ]; then
       "${PREFIX}/lib/libsodium.a" -o "${outFile}" || exit 1
   }
   emmake make $MAKE_FLAGS install || exit 1
-  emccLibsodium "${PREFIX}/lib/libsodium.asm.tmp.js" -Oz -s RUNNING_JS_OPTS=1
+  emccLibsodium "${PREFIX}/lib/libsodium.asm.tmp.js" -Oz -s WASM=0 -s RUNNING_JS_OPTS=1
   emccLibsodium "${PREFIX}/lib/libsodium.wasm.tmp.js" -O3 -s WASM=1
 
   cat > "${PREFIX}/lib/libsodium.js" <<- EOM


### PR DESCRIPTION
Not an immediate issue if libsodium is still stuck on an older version of emscripten pending resolution of https://github.com/kripken/emscripten/issues/6387, but this will be needed when you do upgrade to make sure that the asm.js fallback continues to work as intended.