### PR TITLE
Better handling of --disable-asm option during build.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,9 @@ AS_IF([test "$host_os" = "nacl" -o "$host_os" = "pnacl"], [
   AC_MSG_WARN([compiling to Native Client - asm implementations disabled])
 ])
 
+AS_IF([test "x$enable_asm" = "xno"], [WITH_ASM=0], [WITH_ASM=1])
+AM_CONDITIONAL([WITH_ASM], [test "x$WITH_ASM" != "x0"])
+
 AC_ARG_ENABLE(pie,
 [AS_HELP_STRING(--disable-pie,Do not produce position independent executables)],
  enable_pie=$enableval, enable_pie="maybe")
@@ -599,7 +602,7 @@ __asm__ __volatile__ ("" : : "r"(pnt) : "memory");
 )
 
 HAVE_AMD64_ASM_V=0
-AS_IF([test "$enable_asm" != "no"],[
+AS_IF([test "x$WITH_ASM" != "x0"],[
   AC_MSG_CHECKING(whether we can use x86_64 asm code)
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   ]], [[
@@ -628,7 +631,7 @@ AM_CONDITIONAL([HAVE_AMD64_ASM], [test $HAVE_AMD64_ASM_V = 1])
 AC_SUBST(HAVE_AMD64_ASM_V)
 
 HAVE_AVX_ASM_V=0
-AS_IF([test "$enable_asm" != "no"],[
+AS_IF([test "x$WITH_ASM" != "x0"],[
   AC_MSG_CHECKING(whether we can assemble AVX opcodes)
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   ]], [[
@@ -688,26 +691,29 @@ AM_CONDITIONAL([HAVE_TI_MODE], [test $HAVE_TI_MODE_V = 1])
 AC_SUBST(HAVE_TI_MODE_V)
 
 HAVE_CPUID_V=0
-AS_IF([test "$enable_asm" != "no" -o "$host_alias" = "x86_64-nacl"],[
-  AC_MSG_CHECKING(for cpuid instruction)
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[
+AS_IF([test "x$WITH_ASM" != "x0"],
+  AS_IF(["$host_alias" = "x86_64-nacl"],[
+    AC_MSG_CHECKING(for cpuid instruction)
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[
 unsigned int cpu_info[4];
 __asm__ __volatile__ ("xchgl %%ebx, %k1; cpuid; xchgl %%ebx, %k1" :
                       "=a" (cpu_info[0]), "=&r" (cpu_info[1]),
                       "=c" (cpu_info[2]), "=d" (cpu_info[3]) :
                       "0" (0U), "2" (0U));
-  ]])],
-  [AC_MSG_RESULT(yes)
-   AC_DEFINE([HAVE_CPUID], [1], [cpuid instruction is available])
-   HAVE_CPUID_V=1],
-  [AC_MSG_RESULT(no)])
+    ]])],
+    [AC_MSG_RESULT(yes)
+     AC_DEFINE([HAVE_CPUID], [1], [cpuid instruction is available])
+     HAVE_CPUID_V=1],
+    [AC_MSG_RESULT(no)])
   ])
+])
 AC_SUBST(HAVE_CPUID_V)
 
 asm_hide_symbol="unsupported"
-AS_IF([test "$enable_asm" != "no" -o "$host_os" = "nacl"],[
-  AC_MSG_CHECKING(if the .private_extern asm directive is supported)
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[ ]], [[
+AS_IF([test "x$WITH_ASM" != "x0"],
+  AS_IF(["$host_os" = "nacl"],[
+    AC_MSG_CHECKING(if the .private_extern asm directive is supported)
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[ ]], [[
 __asm__ __volatile__ (".private_extern dummy_symbol \n"
                       ".private_extern _dummy_symbol \n"
                       ".globl dummy_symbol \n"
@@ -716,13 +722,13 @@ __asm__ __volatile__ (".private_extern dummy_symbol \n"
                       "_dummy_symbol: \n"
                       "    nop \n"
 );
-  ]])],
-  [AC_MSG_RESULT(yes)
-   asm_hide_symbol=".private_extern"],
-  [AC_MSG_RESULT(no)])
+    ]])],
+    [AC_MSG_RESULT(yes)
+     asm_hide_symbol=".private_extern"],
+    [AC_MSG_RESULT(no)])
 
-  AC_MSG_CHECKING(if the .hidden asm directive is supported)
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[ ]], [[
+    AC_MSG_CHECKING(if the .hidden asm directive is supported)
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[ ]], [[
 __asm__ __volatile__ (".hidden dummy_symbol \n"
                       ".hidden _dummy_symbol \n"
                       ".globl dummy_symbol \n"
@@ -731,17 +737,18 @@ __asm__ __volatile__ (".hidden dummy_symbol \n"
                       "_dummy_symbol: \n"
                       "    nop \n"
 );
-  ]])],
-  [AC_MSG_RESULT(yes)
-   AS_IF([test "$asm_hide_symbol" = "unsupported"],
-          [asm_hide_symbol=".hidden"],
-          [AC_MSG_NOTICE([unable to reliably tag symbols as private])
-           asm_hide_symbol="unsupported"])
-  ],
-  [AC_MSG_RESULT(no)])
+    ]])],
+    [AC_MSG_RESULT(yes)
+     AS_IF([test "$asm_hide_symbol" = "unsupported"],
+       [asm_hide_symbol=".hidden"],
+       [AC_MSG_NOTICE([unable to reliably tag symbols as private])
+        asm_hide_symbol="unsupported"])
+    ],
+    [AC_MSG_RESULT(no)])
 
-  AS_IF([test "$asm_hide_symbol" != "unsupported"],[
-    AC_DEFINE_UNQUOTED([ASM_HIDE_SYMBOL], [$asm_hide_symbol], [directive to hide symbols])
+    AS_IF([test "$asm_hide_symbol" != "unsupported"],[
+      AC_DEFINE_UNQUOTED([ASM_HIDE_SYMBOL], [$asm_hide_symbol], [directive to hide symbols])
+    ])
   ])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -597,7 +597,7 @@ int *pnt = &a;
 __asm__ __volatile__ ("" : : "r"(pnt) : "memory");
 ]])],
   [AC_MSG_RESULT(yes)
-   AC_DEFINE([HAVE_INLINE_ASM], [1], [inline asm code can be used])]
+   AC_DEFINE([HAVE_INLINE_ASM], [1], [inline asm code can be used])],
   [AC_MSG_RESULT(no)]
 )
 

--- a/src/libsodium/Makefile.am
+++ b/src/libsodium/Makefile.am
@@ -217,6 +217,7 @@ endif
 
 endif
 
+if WITH_ASM
 libaesni_la_LDFLAGS = $(libsodium_la_LDFLAGS)
 libaesni_la_CPPFLAGS = $(libsodium_la_CPPFLAGS) \
 	@CFLAGS_SSE2@ @CFLAGS_SSSE3@ @CFLAGS_AESNI@ @CFLAGS_PCLMUL@
@@ -288,3 +289,4 @@ libavx512f_la_CPPFLAGS = $(libsodium_la_CPPFLAGS) \
 libavx512f_la_SOURCES = \
 	crypto_pwhash/argon2/argon2-fill-block-avx512f.c \
 	crypto_pwhash/argon2/blamka-round-avx512f.h
+endif  ##WITH_ASM


### PR DESCRIPTION
This changeset resolves an issue while building libsodium on non-amd64 platforms. Specifically, a build for x86 (i686 core, say) fails during compilation of certain SSE2 instructions in the xmm6int variant of salsa20 crypto_stream routines, even with the '--disable-asm' configure option. This is due to '--disable-asm' actually implying HAVE_AMD64_ASM=0; xmm6int SSE2 routines are included in the SSE2 library in that case.

These commits expose a new WITH_ASM automake variable for the '--disable-asm' option. WITH_ASM is tied to other asm-related build checks, so the existing HAVE_xxx_ASM configs will never be defined when ASM has been disabled (as expected). Also, '--disable-asm' now means no auxilliary library (sse,avx,aes-ni,etc.) will be built.

Two less-obvious behavioral changes I want to explicitly call out:
* Previously, CPUID check was executed if ASM was allowed OR '$host_alias' = 'x86_64-nacl'. These changes effectively turn this into an AND.
* Previously, the .private_extern directive checks were run if ASM was allowed OR '$host_os' = 'nacl'. Again, these changes effectively turn this into an AND.

Happy to discuss if anything seems amiss. Thanks!