### PR TITLE
Fix warnings in GCC7 related to -Wimplicit-fallthrough

### DIFF
--- a/src/libsodium/crypto_shorthash/siphash24/ref/shorthash_siphash24_ref.c
+++ b/src/libsodium/crypto_shorthash/siphash24/ref/shorthash_siphash24_ref.c
@@ -33,16 +33,22 @@ crypto_shorthash_siphash24(unsigned char *out, const unsigned char *in,
     switch (left) {
     case 7:
         b |= ((uint64_t) in[6]) << 48;
+        /* FALLTHRU */
     case 6:
         b |= ((uint64_t) in[5]) << 40;
+        /* FALLTHRU */
     case 5:
         b |= ((uint64_t) in[4]) << 32;
+        /* FALLTHRU */
     case 4:
         b |= ((uint64_t) in[3]) << 24;
+        /* FALLTHRU */
     case 3:
         b |= ((uint64_t) in[2]) << 16;
+        /* FALLTHRU */
     case 2:
         b |= ((uint64_t) in[1]) << 8;
+        /* FALLTHRU */
     case 1:
         b |= ((uint64_t) in[0]);
         break;

--- a/src/libsodium/crypto_shorthash/siphash24/ref/shorthash_siphashx24_ref.c
+++ b/src/libsodium/crypto_shorthash/siphash24/ref/shorthash_siphashx24_ref.c
@@ -32,16 +32,22 @@ crypto_shorthash_siphashx24(unsigned char *out, const unsigned char *in,
     switch (left) {
     case 7:
         b |= ((uint64_t) in[6]) << 48;
+        /* FALLTHRU */
     case 6:
         b |= ((uint64_t) in[5]) << 40;
+        /* FALLTHRU */
     case 5:
         b |= ((uint64_t) in[4]) << 32;
+        /* FALLTHRU */
     case 4:
         b |= ((uint64_t) in[3]) << 24;
+        /* FALLTHRU */
     case 3:
         b |= ((uint64_t) in[2]) << 16;
+        /* FALLTHRU */
     case 2:
         b |= ((uint64_t) in[1]) << 8;
+        /* FALLTHRU */
     case 1:
         b |= ((uint64_t) in[0]);
         break;


### PR DESCRIPTION
Some warnings appear in gcc 7+

`-Wimplicit-fallthrough`
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html