### PR TITLE
Fix segmentation fault in pwhash_scrypt test

### DIFF
--- a/test/default/pwhash_scrypt.c
+++ b/test/default/pwhash_scrypt.c
@@ -277,14 +277,19 @@ tv3(void)
     char * out;
     char * passwd;
     size_t i = 0U;
+    int out_size;
+    int pass_size;
+    int min_size = crypto_pwhash_scryptsalsa208sha256_STRBYTES;
 
     do {
-        out = (char *) sodium_malloc(strlen(tests[i].out) + 1U);
+        out_size = strlen(tests[i].out) + 1U;
+        pass_size = strlen(tests[i].passwd) + 1U;
+        out = (char *) sodium_malloc((out_size > min_size) ? out_size : min_size);
         assert(out != NULL);
-        memcpy(out, tests[i].out, strlen(tests[i].out) + 1U);
-        passwd = (char *) sodium_malloc(strlen(tests[i].passwd) + 1U);
+        memcpy(out, tests[i].out, out_size);
+        passwd = (char *) sodium_malloc(pass_size);
         assert(passwd != NULL);
-        memcpy(passwd, tests[i].passwd, strlen(tests[i].passwd) + 1U);
+        memcpy(passwd, tests[i].passwd, pass_size);
         if (crypto_pwhash_scryptsalsa208sha256_str_verify(
                 out, passwd, strlen(passwd)) != 0) {
             printf("pwhash_str failure: [%u]\n", (unsigned int) i);


### PR DESCRIPTION
Function `crypto_pwhash_scryptsalsa208sha256_str_verify` expects that first argument length is at least `crypto_pwhash_scryptsalsa208sha256_STRBYTES`:
* https://github.com/jedisct1/libsodium/blob/d25d6ce7fbf940f2e20e668a2a30d066f66e39e2/src/libsodium/crypto_pwhash/scryptsalsa208sha256/pwhash_scryptsalsa208sha256.c#L228-L240

I can reproduce segmentation fault on AppVeyor with Visual Studio 2017:
```
...
pwhash_argon2id.c ok - 0
pwhash_scrypt.c ok - -1073741819
pwhash_scrypt_ll.c ok - 0
...
```

Build:
* https://ci.appveyor.com/project/ruslo/libsodium/build/1.0.13

Configuration:
* https://github.com/ruslo/libsodium/blob/2d7e23f084cea70f292655b525016249b392154e/run-test.bat#L3-L8

Fixed build:
* https://ci.appveyor.com/project/ruslo/libsodium/build/1.0.15

If you want to reproduce it locally then you should apply this patch first to see the error: https://github.com/jedisct1/libsodium/pull/736
Otherwise it still will be shown as `ok`.