### PR TITLE
#747 fix

### DIFF
--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -109,9 +109,9 @@ if [ "$DIST" = yes ]; then
       };
       Module.useBackupModule = function() {
         var Module = _Module;
-        Module.onAbort = undefined;
-        Module.onRuntimeInitialized = undefined;
-        Module.useBackupModule = undefined;
+        Object.keys(Module).forEach(function(k) {
+          delete Module[k];
+        });
         $(cat "${PREFIX}/lib/libsodium.asm.tmp.js" | sed 's|use asm||g')
       };
       $(cat "${PREFIX}/lib/libsodium.wasm.tmp.js")

--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -95,10 +95,10 @@ if [ "$DIST" = yes ]; then
       Module['TOTAL_MEMORY'] = root['sodium']['totalMemory'];
     }
     var _Module = Module;
-    Module.ready = new Promise(function (resolve, reject) {
+    Module.ready = new Promise(function(resolve, reject) {
       var Module = _Module;
       Module.onAbort = reject;
-      Module.onRuntimeInitialized = function () {
+      Module.onRuntimeInitialized = function() {
         try {
           /* Test arbitrary wasm function */
           Module._crypto_secretbox_keybytes();
@@ -107,7 +107,7 @@ if [ "$DIST" = yes ]; then
           reject(err);
         }
       };
-      Module.useBackupModule = function () {
+      Module.useBackupModule = function() {
         var Module = _Module;
         Module.onAbort = undefined;
         Module.onRuntimeInitialized = undefined;
@@ -115,7 +115,7 @@ if [ "$DIST" = yes ]; then
         $(cat "${PREFIX}/lib/libsodium.asm.tmp.js" | sed 's|use asm||g')
       };
       $(cat "${PREFIX}/lib/libsodium.wasm.tmp.js")
-    }).catch(function () {
+    }).catch(function() {
       _Module.useBackupModule();
     });
 EOM


### PR DESCRIPTION
Fixes an issue I caught while testing the rebuilt libsodium.js after https://github.com/jedisct1/libsodium/pull/747 / https://github.com/jedisct1/libsodium.js/pull/166.

Unfortunately, I'm not sure yet why `sodium.crypto_secretbox_open_easy()` is failing with `ReferenceError: var_size is not defined`, if this will somehow also resolve that, or if that's even related to my commits.

Related: https://github.com/jedisct1/libsodium.js/pull/167