### PR TITLE
useBackupModule getRandomValue fix

### DIFF
--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -110,7 +110,9 @@ if [ "$DIST" = yes ]; then
       Module.useBackupModule = function() {
         var Module = _Module;
         Object.keys(Module).forEach(function(k) {
-          delete Module[k];
+          if (k !== 'getRandomValue') {
+            delete Module[k];
+          }
         });
         $(cat "${PREFIX}/lib/libsodium.asm.tmp.js" | sed 's|use asm||g')
       };


### PR DESCRIPTION
Fixes a minor issue with #752 (run-time error when running any sodium method after `sodium.libsodium.useBackupModule()` has been called).