### PR TITLE
Made sig parameter of crypto_sign_final_verify() const

### DIFF
--- a/src/libsodium/crypto_sign/crypto_sign.c
+++ b/src/libsodium/crypto_sign/crypto_sign.c
@@ -108,7 +108,7 @@ crypto_sign_final_create(crypto_sign_state *state, unsigned char *sig,
 }
 
 int
-crypto_sign_final_verify(crypto_sign_state *state, unsigned char *sig,
+crypto_sign_final_verify(crypto_sign_state *state, const unsigned char *sig,
                          const unsigned char *pk)
 {
     return crypto_sign_ed25519ph_final_verify(state, sig, pk);

--- a/src/libsodium/crypto_sign/ed25519/sign_ed25519.c
+++ b/src/libsodium/crypto_sign/ed25519/sign_ed25519.c
@@ -86,7 +86,7 @@ crypto_sign_ed25519ph_final_create(crypto_sign_ed25519ph_state *state,
 
 int
 crypto_sign_ed25519ph_final_verify(crypto_sign_ed25519ph_state *state,
-                                   unsigned char               *sig,
+                                   const unsigned char         *sig,
                                    const unsigned char         *pk)
 {
     unsigned char ph[crypto_hash_sha512_BYTES];

--- a/src/libsodium/include/sodium/crypto_sign.h
+++ b/src/libsodium/include/sodium/crypto_sign.h
@@ -96,7 +96,7 @@ int crypto_sign_final_create(crypto_sign_state *state, unsigned char *sig,
             __attribute__ ((nonnull(1, 2, 4)));
 
 SODIUM_EXPORT
-int crypto_sign_final_verify(crypto_sign_state *state, unsigned char *sig,
+int crypto_sign_final_verify(crypto_sign_state *state, const unsigned char *sig,
                              const unsigned char *pk)
             __attribute__ ((warn_unused_result)) __attribute__ ((nonnull));
 

--- a/src/libsodium/include/sodium/crypto_sign_ed25519.h
+++ b/src/libsodium/include/sodium/crypto_sign_ed25519.h
@@ -113,7 +113,7 @@ int crypto_sign_ed25519ph_final_create(crypto_sign_ed25519ph_state *state,
 
 SODIUM_EXPORT
 int crypto_sign_ed25519ph_final_verify(crypto_sign_ed25519ph_state *state,
-                                       unsigned char *sig,
+                                       const unsigned char *sig,
                                        const unsigned char *pk)
             __attribute__ ((warn_unused_result)) __attribute__ ((nonnull));
 


### PR DESCRIPTION
The functions `crypto_sign_final_verify()` and `crypto_sign_ed25519ph_final_verify()` only read the contents of the `sig` parameter, so it can be safely made `const`. This makes the API easier to use for callers who only have a const pointer to the signature (especially in C++, which requires a verbose `const_cast<unsigned char*>(sig)` currently).