### PR TITLE
Add a public API to sign/verify pre-hashed messages with Ed25519ph

### DIFF
--- a/src/libsodium/crypto_sign/ed25519/sign_ed25519.c
+++ b/src/libsodium/crypto_sign/ed25519/sign_ed25519.c
@@ -81,7 +81,7 @@ crypto_sign_ed25519ph_final_create(crypto_sign_ed25519ph_state *state,
 
     crypto_hash_sha512_final(&state->hs, ph);
 
-    return _crypto_sign_ed25519_detached(sig, siglen_p, ph, sizeof ph, sk, 1);
+    return crypto_sign_ed25519ph_prehashed(ph, sizeof ph, sig, siglen_p, sk);
 }
 
 int
@@ -93,5 +93,28 @@ crypto_sign_ed25519ph_final_verify(crypto_sign_ed25519ph_state *state,
 
     crypto_hash_sha512_final(&state->hs, ph);
 
-    return _crypto_sign_ed25519_verify_detached(sig, ph, sizeof ph, pk, 1);
+    return crypto_sign_ed25519ph_verify_prehashed(ph, sizeof ph, sig, pk);
+}
+
+int crypto_sign_ed25519ph_prehashed(const unsigned char *mhash,
+                                    unsigned long long mhashlen,
+                                    unsigned char *sig,
+                                    unsigned long long *siglen_p,
+                                    const unsigned char *sk)
+{
+  if (mhashlen != crypto_hash_sha512_BYTES) {
+    return -1;
+  }
+  return _crypto_sign_ed25519_detached(sig, siglen_p, mhash, mhashlen, sk, 1);
+}
+
+int crypto_sign_ed25519ph_verify_prehashed(const unsigned char *mhash,
+                                           unsigned long long mhashlen,
+                                           const unsigned char *sig,
+                                           const unsigned char *pk)
+{
+  if (mhashlen != crypto_hash_sha512_BYTES) {
+    return -1;
+  }
+  return _crypto_sign_ed25519_verify_detached(sig, mhash, mhashlen, pk, 1);
 }

--- a/src/libsodium/include/sodium/crypto_sign_ed25519.h
+++ b/src/libsodium/include/sodium/crypto_sign_ed25519.h
@@ -117,6 +117,29 @@ int crypto_sign_ed25519ph_final_verify(crypto_sign_ed25519ph_state *state,
                                        const unsigned char *pk)
             __attribute__ ((warn_unused_result)) __attribute__ ((nonnull));
 
+// signs a pre-hashed message.
+// mhash is a pointer to the sha512 digest of the message to be signed.
+// mhashlen must equal crypto_hash_sha512_BYTES.
+// Other parameters are same as for crypto_sign_ed25519ph_final_create()
+SODIUM_EXPORT
+int crypto_sign_ed25519ph_prehashed(const unsigned char *mhash,
+                                    unsigned long long mhashlen,
+                                    unsigned char *sig,
+                                    unsigned long long *siglen_p,
+                                    const unsigned char *sk)
+            __attribute__ ((nonnull));
+
+// verifies a pre-hashed message.
+// mhash is a pointer to the sha512 digest of the message to be verified.
+// mhashlen must equal crypto_hash_sha512_BYTES.
+// Other parameters are same as for crypto_sign_ed25519ph_final_verify()
+SODIUM_EXPORT
+int crypto_sign_ed25519ph_verify_prehashed(const unsigned char *mhash,
+                                           unsigned long long mhashlen,
+                                           const unsigned char *sig,
+                                           const unsigned char *pk)
+            __attribute__ ((warn_unused_result)) __attribute__ ((nonnull));
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add a public API to sign/verify messages pre-hashed by the caller with Ed25519ph. This makes it possible to use libsodium to efficiently implement a remote signing service, for example (caller can hash a large message and send the digest only to the service for signing).

This fixes #789.