### PR TITLE
Add -pthread to pkgconfig's Libs.private if enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,7 @@ AC_SUBST(DLL_VERSION)
 
 AC_LANG_ASSERT(C)
 LX_CFLAGS=${CFLAGS-NONE}
+PKGCONFIG_LIBS_PRIVATE=""
 
 dnl Path check
 
@@ -127,6 +128,7 @@ AS_IF([test "x$withval" = "xyes"], [
     AC_DEFINE([HAVE_PTHREAD], [1], [Define if you have POSIX threads libraries and header files])
     with_threads="yes"
     LIBS="$PTHREAD_LIBS $LIBS"
+    PKGCONFIG_LIBS_PRIVATE="$PTHREAD_LIBS $PTHREAD_CFLAGS $PKGCONFIG_LIBS_PRIVATE"
     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
     CC="$PTHREAD_CC"])
 ], [with_threads="no"])
@@ -193,6 +195,7 @@ AC_ARG_ENABLE(opt,
 ])
 
 AC_SUBST([MAINT])
+AC_SUBST(PKGCONFIG_LIBS_PRIVATE, $PKGCONFIG_LIBS_PRIVATE)
 
 AX_VALGRIND_CHECK
 

--- a/libsodium-uninstalled.pc.in
+++ b/libsodium-uninstalled.pc.in
@@ -3,4 +3,5 @@ Version: @PACKAGE_VERSION@
 Description: A modern and easy-to-use crypto library
 
 Libs: -L${pcfiledir}/src/libsodium -lsodium
+Libs.private: @PKGCONFIG_LIBS_PRIVATE@
 Cflags: -I${pcfiledir}/src/libsodium/include -I@top_srcdir@/src/libsodium/include -I@top_srcdir@/src/libsodium/include/sodium

--- a/libsodium.pc.in
+++ b/libsodium.pc.in
@@ -8,4 +8,5 @@ Version: @PACKAGE_VERSION@
 Description: A modern and easy-to-use crypto library
 
 Libs: -L${libdir} -lsodium
+Libs.private: @PKGCONFIG_LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
Allows static builds to correctly inherit the pthread dependency when
used with pkg-config --static --libs libsodium