### PR TITLE
Ed25519: add EdDSA-Ed25519-Blake2b-512 signing variant

### DIFF
--- a/src/libsodium/Makefile.am
+++ b/src/libsodium/Makefile.am
@@ -73,6 +73,9 @@ libsodium_la_SOURCES = \
 	crypto_sign/ed25519/ref10/open.c \
 	crypto_sign/ed25519/ref10/sign.c \
 	crypto_sign/ed25519/ref10/sign_ed25519_ref10.h \
+	crypto_sign/ed25519/blake2b/keypair.c \
+	crypto_sign/ed25519/blake2b/open.c \
+	crypto_sign/ed25519/blake2b/sign.c \
 	crypto_stream/chacha20/stream_chacha20.c \
 	crypto_stream/chacha20/stream_chacha20.h \
 	crypto_stream/chacha20/ref/chacha20_ref.h \

--- a/src/libsodium/crypto_sign/ed25519/blake2b/crypto_sign_ed25519_blake2b.h
+++ b/src/libsodium/crypto_sign/ed25519/blake2b/crypto_sign_ed25519_blake2b.h
@@ -1,0 +1,20 @@
+#ifndef sign_ed25519_blake2b_H
+#define sign_ed25519_blake2b_H
+
+void _crypto_sign_ed25519_blake2b_hinit(crypto_generichash_blake2b_state *hs,
+                                        const unsigned char *salt,
+                                        const unsigned char *personal);
+
+int _crypto_sign_ed25519_blake2b_detached(unsigned char *sig,
+                                          unsigned long long *siglen_p,
+                                          const unsigned char *m,
+                                          unsigned long long mlen,
+                                          const unsigned char *sk,
+                                          const unsigned char *personal);
+
+int _crypto_sign_ed25519_blake2b_verify_detached(const unsigned char *sig,
+                                                 const unsigned char *m,
+                                                 unsigned long long   mlen,
+                                                 const unsigned char *pk,
+                                                 const unsigned char *personal);
+#endif

--- a/src/libsodium/crypto_sign/ed25519/blake2b/keypair.c
+++ b/src/libsodium/crypto_sign/ed25519/blake2b/keypair.c
@@ -1,0 +1,40 @@
+
+#include <string.h>
+
+#include "crypto_generichash_blake2b.h"
+#include "private/ed25519_ref10.h"
+#include "randombytes.h"
+#include "utils.h"
+
+int
+crypto_sign_ed25519_blake2b_seed_keypair(unsigned char *pk, unsigned char *sk,
+                                         const unsigned char *seed)
+{
+    ge25519_p3 A;
+
+    crypto_generichash_blake2b(sk, 64, seed, 32, NULL, 0);
+    sk[0] &= 248;
+    sk[31] &= 127;
+    sk[31] |= 64;
+
+    ge25519_scalarmult_base(&A, sk);
+    ge25519_p3_tobytes(pk, &A);
+
+    memmove(sk, seed, 32);
+    memmove(sk + 32, pk, 32);
+
+    return 0;
+}
+
+int
+crypto_sign_ed25519_blake2b_keypair(unsigned char *pk, unsigned char *sk)
+{
+    unsigned char seed[32];
+    int           ret;
+
+    randombytes_buf(seed, sizeof seed);
+    ret = crypto_sign_ed25519_blake2b_seed_keypair(pk, sk, seed);
+    sodium_memzero(seed, sizeof seed);
+
+    return ret;
+}

--- a/src/libsodium/crypto_sign/ed25519/blake2b/open.c
+++ b/src/libsodium/crypto_sign/ed25519/blake2b/open.c
@@ -1,0 +1,99 @@
+
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "crypto_generichash_blake2b.h"
+#include "crypto_sign_ed25519.h"
+#include "crypto_sign_ed25519_blake2b.h"
+#include "crypto_verify_32.h"
+#include "private/ed25519_ref10.h"
+#include "utils.h"
+
+int
+_crypto_sign_ed25519_blake2b_verify_detached(const unsigned char *sig,
+                                             const unsigned char *m,
+                                             unsigned long long   mlen,
+                                             const unsigned char *pk,
+                                             const unsigned char *personal)
+{
+    crypto_generichash_blake2b_state hs;
+    const unsigned char      salt[16] = { 0x00 };
+    unsigned char            h[64];
+    unsigned char            rcheck[32];
+    ge25519_p3               A;
+    ge25519_p2               R;
+
+#ifdef ED25519_COMPAT
+    if (sig[63] & 224) {
+        return -1;
+    }
+#else
+    if (sc25519_is_canonical(sig + 32) == 0 ||
+        ge25519_has_small_order(sig) != 0) {
+        return -1;
+    }
+    if (ge25519_is_canonical(pk) == 0 ||
+        ge25519_has_small_order(pk) != 0) {
+        return -1;
+    }
+#endif
+    if (ge25519_frombytes_negate_vartime(&A, pk) != 0) {
+        return -1;
+    }
+    _crypto_sign_ed25519_blake2b_hinit(&hs, salt, personal);
+    crypto_generichash_blake2b_update(&hs, sig, 32);
+    crypto_generichash_blake2b_update(&hs, pk, 32);
+    crypto_generichash_blake2b_update(&hs, m, mlen);
+    crypto_generichash_blake2b_final(&hs, h, 64);
+    sc25519_reduce(h);
+
+    ge25519_double_scalarmult_vartime(&R, h, &A, sig + 32);
+    ge25519_tobytes(rcheck, &R);
+
+    return crypto_verify_32(rcheck, sig) | (-(rcheck == sig)) |
+           sodium_memcmp(sig, rcheck, 32);
+}
+
+int
+crypto_sign_ed25519_blake2b_verify_detached(const unsigned char *sig,
+                                    const unsigned char *m,
+                                    unsigned long long   mlen,
+                                    const unsigned char *pk,
+                                    const unsigned char *personal)
+{
+    return _crypto_sign_ed25519_blake2b_verify_detached(sig, m, mlen, pk, personal);
+}
+
+int
+crypto_sign_ed25519_blake2b_open(unsigned char *m, unsigned long long *mlen_p,
+                                 const unsigned char *sm, unsigned long long smlen,
+                                 const unsigned char *pk,
+                                 const unsigned char *personal)
+{
+    unsigned long long mlen;
+
+    if (smlen < 64 || smlen - 64 > crypto_sign_ed25519_MESSAGEBYTES_MAX) {
+        goto badsig;
+    }
+    mlen = smlen - 64;
+    if (crypto_sign_ed25519_verify_detached(sm, sm + 64, mlen, pk) != 0) {
+        if (m != NULL) {
+            memset(m, 0, mlen);
+        }
+        goto badsig;
+    }
+    if (mlen_p != NULL) {
+        *mlen_p = mlen;
+    }
+    if (m != NULL) {
+        memmove(m, sm + 64, mlen);
+    }
+    return 0;
+
+badsig:
+    if (mlen_p != NULL) {
+        *mlen_p = 0;
+    }
+    return -1;
+}

--- a/src/libsodium/crypto_sign/ed25519/blake2b/sign.c
+++ b/src/libsodium/crypto_sign/ed25519/blake2b/sign.c
@@ -1,0 +1,138 @@
+
+#include <string.h>
+
+#include "crypto_generichash_blake2b.h"
+#include "crypto_sign_ed25519.h"
+#include "crypto_sign_ed25519_blake2b.h"
+#include "private/ed25519_ref10.h"
+#include "randombytes.h"
+#include "utils.h"
+
+void _crypto_sign_ed25519_blake2b_hinit(crypto_generichash_blake2b_state *hs,
+                                        const unsigned char *salt,
+                                        const unsigned char *personal)
+{
+  crypto_generichash_blake2b_init_salt_personal(hs, NULL, 0, 64, salt, personal);
+}
+
+static inline void
+_crypto_sign_ed25519_blake2b_clamp(unsigned char k[32])
+{
+    k[0] &= 248;
+    k[31] &= 127;
+    k[31] |= 64;
+}
+#ifdef ED25519_NONDETERMINISTIC
+
+/* r = hash(B || empty_labelset || Z || pad1 || k || pad2 || empty_labelset || K || extra || M) (mod q) */
+static void
+_crypto_sign_ed25519_blake2b_synthetic_r_hv(crypto_generichash_blake2b_state *hs,
+                                    unsigned char Z[32],
+                                    const unsigned char sk[64])
+{
+    static const unsigned char B[32] = {
+        0x58, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+        0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+        0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+        0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+    };
+    static const unsigned char zeros[128] = { 0x00 };
+    static const unsigned char empty_labelset[3] = { 0x02, 0x00, 0x00 };
+
+    crypto_generichash_blake2b_update(hs, B, 32);
+    crypto_generichash_blake2b_update(hs, empty_labelset, 3);
+    randombytes_buf(Z, 32);
+    crypto_generichash_blake2b_update(hs, Z, 32);
+    crypto_generichash_blake2b_update(hs, zeros, 128 - (32 + 3 + 32) % 128);
+    crypto_generichash_blake2b_update(hs, sk, 32);
+    crypto_generichash_blake2b_update(hs, zeros, 128 - 32 % 128);
+    crypto_generichash_blake2b_update(hs, empty_labelset, 3);
+    crypto_generichash_blake2b_update(hs, sk + 32, 32);
+    /* empty extra */
+}
+#endif
+
+int
+_crypto_sign_ed25519_blake2b_detached(unsigned char *sig, unsigned long long *siglen_p,
+                                      const unsigned char *m, unsigned long long mlen,
+                                      const unsigned char *sk,
+                                      const unsigned char *personal)
+{
+    crypto_generichash_blake2b_state hs;
+    unsigned char            salt[16] = { 0x00 };
+    unsigned char            az[64];
+    unsigned char            nonce[64];
+    unsigned char            hram[64];
+    ge25519_p3               R;
+
+    _crypto_sign_ed25519_blake2b_hinit(&hs, salt, personal);
+
+    crypto_generichash_blake2b(az, 64, sk, 32, NULL, 0);
+#ifdef ED25519_NONDETERMINISTIC
+    _crypto_sign_ed25519_blake2b_synthetic_r_hv(&hs, nonce, az);
+#else
+    crypto_generichash_blake2b_update(&hs, az + 32, 32);
+#endif
+
+    crypto_generichash_blake2b_update(&hs, m, mlen);
+    crypto_generichash_blake2b_final(&hs, nonce, 64);
+
+    memmove(sig + 32, sk + 32, 32);
+
+    sc25519_reduce(nonce);
+    ge25519_scalarmult_base(&R, nonce);
+    ge25519_p3_tobytes(sig, &R);
+
+    _crypto_sign_ed25519_blake2b_hinit(&hs, salt, personal);
+    crypto_generichash_blake2b_update(&hs, sig, 64);
+    crypto_generichash_blake2b_update(&hs, m, mlen);
+    crypto_generichash_blake2b_final(&hs, hram, 64);
+
+    sc25519_reduce(hram);
+    _crypto_sign_ed25519_blake2b_clamp(az);
+    sc25519_muladd(sig + 32, hram, az, nonce);
+
+    sodium_memzero(az, sizeof az);
+    sodium_memzero(nonce, sizeof nonce);
+
+    if (siglen_p != NULL) {
+        *siglen_p = 64U;
+    }
+    return 0;
+}
+
+int
+crypto_sign_ed25519_blake2b_detached(unsigned char *sig, unsigned long long *siglen_p,
+                                     const unsigned char *m, unsigned long long mlen,
+                                     const unsigned char *sk,
+                                     const unsigned char *personal)
+{
+    return _crypto_sign_ed25519_blake2b_detached(sig, siglen_p, m, mlen, sk, personal);
+}
+
+int
+crypto_sign_ed25519_blake2b(unsigned char *sm, unsigned long long *smlen_p,
+                            const unsigned char *m, unsigned long long mlen,
+                            const unsigned char *sk,
+                            const unsigned char *personal)
+{
+    unsigned long long siglen;
+
+    memmove(sm + crypto_sign_ed25519_BYTES, m, mlen);
+    /* LCOV_EXCL_START */
+    if (crypto_sign_ed25519_blake2b_detached(
+            sm, &siglen, sm + crypto_sign_ed25519_BYTES, mlen, sk, personal) != 0 ||
+        siglen != crypto_sign_ed25519_BYTES) {
+        if (smlen_p != NULL) {
+            *smlen_p = 0;
+        }
+        memset(sm, 0, mlen + crypto_sign_ed25519_BYTES);
+        return -1;
+    }
+    /* LCOV_EXCL_STOP */
+
+    if (smlen_p != NULL) {
+        *smlen_p = mlen + siglen;
+    }
+    return 0;
+}

--- a/src/libsodium/include/sodium/crypto_sign_ed25519.h
+++ b/src/libsodium/include/sodium/crypto_sign_ed25519.h
@@ -46,9 +46,23 @@ int crypto_sign_ed25519(unsigned char *sm, unsigned long long *smlen_p,
             __attribute__ ((nonnull(1, 3, 5)));
 
 SODIUM_EXPORT
+int crypto_sign_ed25519_blake2b(unsigned char *sm, unsigned long long *smlen_p,
+                                const unsigned char *m, unsigned long long mlen,
+                                const unsigned char *sk,
+                                const unsigned char *personal)
+            __attribute__ ((nonnull(1, 3, 5)));
+
+SODIUM_EXPORT
 int crypto_sign_ed25519_open(unsigned char *m, unsigned long long *mlen_p,
                              const unsigned char *sm, unsigned long long smlen,
                              const unsigned char *pk)
+            __attribute__ ((warn_unused_result)) __attribute__ ((nonnull(3, 5)));
+
+SODIUM_EXPORT
+int crypto_sign_ed25519_blake2b_open(unsigned char *m, unsigned long long *mlen_p,
+                                     const unsigned char *sm, unsigned long long smlen,
+                                     const unsigned char *pk,
+                                     const unsigned char *personal)
             __attribute__ ((warn_unused_result)) __attribute__ ((nonnull(3, 5)));
 
 SODIUM_EXPORT
@@ -60,10 +74,27 @@ int crypto_sign_ed25519_detached(unsigned char *sig,
             __attribute__ ((nonnull(1, 3)));
 
 SODIUM_EXPORT
+int crypto_sign_ed25519_blake2b_detached(unsigned char *sig,
+                                         unsigned long long *siglen_p,
+                                         const unsigned char *m,
+                                         unsigned long long mlen,
+                                         const unsigned char *sk,
+                                         const unsigned char *personal)
+            __attribute__ ((nonnull(1, 3)));
+
+SODIUM_EXPORT
 int crypto_sign_ed25519_verify_detached(const unsigned char *sig,
                                         const unsigned char *m,
                                         unsigned long long mlen,
                                         const unsigned char *pk)
+            __attribute__ ((warn_unused_result));
+
+SODIUM_EXPORT
+int crypto_sign_ed25519_blake2b_verify_detached(const unsigned char *sig,
+                                                const unsigned char *m,
+                                                unsigned long long mlen,
+                                                const unsigned char *pk,
+                                                const unsigned char *personal)
             __attribute__ ((warn_unused_result));
 
 SODIUM_EXPORT
@@ -73,6 +104,15 @@ int crypto_sign_ed25519_keypair(unsigned char *pk, unsigned char *sk)
 SODIUM_EXPORT
 int crypto_sign_ed25519_seed_keypair(unsigned char *pk, unsigned char *sk,
                                      const unsigned char *seed)
+            __attribute__ ((nonnull));
+
+SODIUM_EXPORT
+int crypto_sign_ed25519_blake2b_keypair(unsigned char *pk, unsigned char *sk)
+            __attribute__ ((nonnull));
+
+SODIUM_EXPORT
+int crypto_sign_ed25519_blake2b_seed_keypair(unsigned char *pk, unsigned char *sk,
+                                             const unsigned char *seed)
             __attribute__ ((nonnull));
 
 SODIUM_EXPORT


### PR DESCRIPTION
Copy of ref10 code, adding EdDSA-Ed25519-Blake2b-512 variant.

Replaces internal use of Sha-512 with Blake2b-512, protects against [Length Extension Attacks](https://en.wikipedia.org/wiki/Length_extension_attack).

