### PR TITLE
Fix placement of alignment specifier

### DIFF
--- a/src/libsodium/include/sodium/crypto_aead_aes256gcm.h
+++ b/src/libsodium/include/sodium/crypto_aead_aes256gcm.h
@@ -56,7 +56,7 @@ size_t crypto_aead_aes256gcm_abytes(void);
 SODIUM_EXPORT
 size_t crypto_aead_aes256gcm_messagebytes_max(void);
 
-typedef CRYPTO_ALIGN(16) struct crypto_aead_aes256gcm_state_ {
+typedef struct CRYPTO_ALIGN(16) crypto_aead_aes256gcm_state_ {
     unsigned char opaque[512];
 } crypto_aead_aes256gcm_state;
 


### PR DESCRIPTION
I guess this was the original intent for the alignment specifier?