### PR TITLE
Add incremental mode for shorthash / siphash2,4.

### DIFF
--- a/src/libsodium/crypto_shorthash/crypto_shorthash.c
+++ b/src/libsodium/crypto_shorthash/crypto_shorthash.c
@@ -32,3 +32,25 @@ crypto_shorthash_keygen(unsigned char k[crypto_shorthash_KEYBYTES])
 {
     randombytes_buf(k, crypto_shorthash_KEYBYTES);
 }
+
+int
+crypto_shorthash_init(crypto_shorthash_state *state,
+                      const unsigned char *k)
+{
+    return crypto_shorthash_siphash24_init(state, k);
+}
+
+int
+crypto_shorthash_update(crypto_shorthash_state *state,
+                        const unsigned char *in,
+                        unsigned long long inlen)
+{
+    return crypto_shorthash_siphash24_update(state, in, inlen);
+}
+
+int
+crypto_shorthash_final(crypto_shorthash_state *state,
+                       unsigned char *out)
+{
+    return crypto_shorthash_siphash24_final(state, out);
+}

--- a/src/libsodium/crypto_shorthash/siphash24/ref/shorthash_siphash24_ref.c
+++ b/src/libsodium/crypto_shorthash/siphash24/ref/shorthash_siphash24_ref.c
@@ -63,3 +63,123 @@ crypto_shorthash_siphash24(unsigned char *out, const unsigned char *in,
 
     return 0;
 }
+
+int
+crypto_shorthash_siphash24_init(crypto_shorthash_siphash24_state *state,
+                                const unsigned char *k)
+{
+    state->v0 = 0x736f6d6570736575ULL;
+    state->v1 = 0x646f72616e646f6dULL;
+    state->v2 = 0x6c7967656e657261ULL;
+    state->v3 = 0x7465646279746573ULL;
+    state->m = 0;
+    state->m_shift = 0;
+    state->len = 0;
+
+    uint64_t k0 = LOAD64_LE(k);
+    uint64_t k1 = LOAD64_LE(k + 8);
+
+    state->v3 ^= k1;
+    state->v2 ^= k0;
+    state->v1 ^= k1;
+    state->v0 ^= k0;
+
+    return 0;
+}
+
+#define LOADSTATE(state)                                    \
+    do {                                                    \
+        v0 = (state)->v0;                                   \
+        v1 = (state)->v1;                                   \
+        v2 = (state)->v2;                                   \
+        v3 = (state)->v3;                                   \
+        m = (state)->m;                                     \
+        m_shift = (state)->m_shift;                         \
+        len = (state)->len;                                 \
+    } while (0)
+
+#define SAVESTATE(state)                                    \
+    do {                                                    \
+        (state)->v0 = v0;                                   \
+        (state)->v1 = v1;                                   \
+        (state)->v2 = v2;                                   \
+        (state)->v3 = v3;                                   \
+        (state)->m = m;                                     \
+        (state)->m_shift = m_shift;                         \
+        (state)->len = len;                                 \
+    } while (0)
+
+#define DIGEST_WORD(w)                          \
+    do {                                        \
+        v3 ^= w;                                \
+        SIPROUND;                               \
+        SIPROUND;                               \
+        v0 ^= w;                                \
+    } while (0)
+
+int
+crypto_shorthash_siphash24_update(crypto_shorthash_siphash24_state *state,
+                                  const unsigned char *in,
+                                  unsigned long long inlen)
+{
+    uint64_t v0, v1, v2, v3, m;
+    uint8_t m_shift, len;
+    const uint8_t *end = in + inlen;
+    const uint8_t *end8;
+    LOADSTATE(state);
+
+    /* Part 1: flush prefix to next 8-byte state-variable boundary. */
+    for (;m_shift != 0 && in != end; ++in) {
+        m |= ((uint64_t)*in) << m_shift;
+        m_shift += 8;
+        if (m_shift == 64) {
+            DIGEST_WORD(m);
+            m = 0;
+            m_shift = 0;
+        }
+    }
+
+    end8 = end - ((end - in) & 7);
+    /* Part 2: proceed in 8-byte words as long as possible. */
+    for (;in != end8; in += sizeof(uint64_t)) {
+        m = LOAD64_LE(in);
+        DIGEST_WORD(m);
+        m = 0;
+    }
+
+    /* Part 3: continue byte-at-a-time through remainder. */
+    for (;in != end; ++in) {
+        m |= ((uint64_t)*in) << m_shift;
+        m_shift += 8;
+        if (m_shift == 64) {
+            DIGEST_WORD(m);
+            m = 0;
+            m_shift = 0;
+        }
+    }
+
+    len += inlen;
+    SAVESTATE(state);
+    return 0;
+}
+
+int
+crypto_shorthash_siphash24_final(crypto_shorthash_siphash24_state *state,
+                                 unsigned char *out)
+{
+    uint64_t v0, v1, v2, v3, m, b;
+    uint8_t m_shift, len;
+
+    LOADSTATE(state);
+    b = m | (((uint64_t)len) << 56);
+    DIGEST_WORD(b);
+    v2 ^= 0xff;
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+
+    b = v0 ^ v1 ^ v2 ^ v3;
+    STORE64_LE(out, b);
+    return 0;
+}

--- a/src/libsodium/include/sodium/crypto_shorthash.h
+++ b/src/libsodium/include/sodium/crypto_shorthash.h
@@ -32,6 +32,21 @@ int crypto_shorthash(unsigned char *out, const unsigned char *in,
 SODIUM_EXPORT
 void crypto_shorthash_keygen(unsigned char k[crypto_shorthash_KEYBYTES]);
 
+typedef crypto_shorthash_siphash24_state crypto_shorthash_state;
+
+SODIUM_EXPORT
+int crypto_shorthash_init(crypto_shorthash_state *state,
+                          const unsigned char *k);
+
+SODIUM_EXPORT
+int crypto_shorthash_update(crypto_shorthash_state *state,
+                            const unsigned char *in,
+                            unsigned long long inlen);
+
+SODIUM_EXPORT
+int crypto_shorthash_final(crypto_shorthash_state *state,
+                           unsigned char *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libsodium/include/sodium/crypto_shorthash_siphash24.h
+++ b/src/libsodium/include/sodium/crypto_shorthash_siphash24.h
@@ -2,6 +2,7 @@
 #define crypto_shorthash_siphash24_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include "export.h"
 
 #ifdef __cplusplus
@@ -10,6 +11,16 @@
 # endif
 extern "C" {
 #endif
+
+typedef struct CRYPTO_ALIGN(16) crypto_shorthash_siphash24_state {
+    uint64_t       v0;
+    uint64_t       v1;
+    uint64_t       v2;
+    uint64_t       v3;
+    uint64_t       m;
+    uint8_t        m_shift;
+    uint8_t        len;
+} crypto_shorthash_siphash24_state;
 
 /* -- 64-bit output -- */
 
@@ -24,6 +35,19 @@ size_t crypto_shorthash_siphash24_keybytes(void);
 SODIUM_EXPORT
 int crypto_shorthash_siphash24(unsigned char *out, const unsigned char *in,
                                unsigned long long inlen, const unsigned char *k);
+
+SODIUM_EXPORT
+int crypto_shorthash_siphash24_init(crypto_shorthash_siphash24_state *state,
+                                    const unsigned char *k);
+
+SODIUM_EXPORT
+int crypto_shorthash_siphash24_update(crypto_shorthash_siphash24_state *state,
+                                      const unsigned char *in,
+                                      unsigned long long inlen);
+
+SODIUM_EXPORT
+int crypto_shorthash_siphash24_final(crypto_shorthash_siphash24_state *state,
+                                     unsigned char *out);
 
 #ifndef SODIUM_LIBRARY_MINIMAL
 /* -- 128-bit output -- */

--- a/test/default/shorthash.c
+++ b/test/default/shorthash.c
@@ -9,9 +9,12 @@ main(void)
 {
     unsigned char in[MAXLEN];
     unsigned char out[crypto_shorthash_BYTES];
+    unsigned char out_incr[crypto_shorthash_BYTES];
     unsigned char k[crypto_shorthash_KEYBYTES];
     size_t        i;
     size_t        j;
+    size_t        half_i;
+    crypto_shorthash_state state;
 
     for (i = 0; i < crypto_shorthash_KEYBYTES; ++i) {
         k[i] = (unsigned char) i;
@@ -23,6 +26,14 @@ main(void)
             printf("%02x", (unsigned int) out[j]);
         }
         printf("\n");
+
+        /* Check that the incremental mode gives same result. */
+        crypto_shorthash_init(&state, k);
+        half_i = i/2;
+        crypto_shorthash_update(&state, in, (unsigned long long) half_i);
+        crypto_shorthash_update(&state, in+half_i, (unsigned long long) (i - half_i));
+        crypto_shorthash_final(&state, out_incr);
+        assert(memcmp(out, out_incr, crypto_shorthash_BYTES) == 0);
     }
     assert(crypto_shorthash_bytes() > 0);
     assert(crypto_shorthash_keybytes() > 0);


### PR DESCRIPTION
This does a simple incremental mode for the shorthash / siphash2,4 implementation. Modeled on the generichash routines. Itch-scratching on our end -- we want a hashtable that can hash things without having to allocate a buffer and serialize the object. Performs better (and more evenly) if we can use a fixed-size buffer and scan/flush it as we pass over the object.
