### PR TITLE
Override print and printErr

### DIFF
--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -100,10 +100,14 @@ if [ "$DIST" = yes ]; then
       var Module = _Module;
       Module.onAbort = reject;
       Module.print = function(what) {
-        console.log(what);
+        if (console != null) {
+          console.log(what);
+        }
       }
       Module.printErr = function(what) {
-        console.warn(what);
+        if (console != null) {
+          console.warn(what);
+        }
       }
       Module.onRuntimeInitialized = function() {
         try {

--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -99,6 +99,12 @@ if [ "$DIST" = yes ]; then
     Module.ready = new Promise(function(resolve, reject) {
       var Module = _Module;
       Module.onAbort = reject;
+      Module.print = function(what) {
+        console.log(what);
+      }
+      Module.printErr = function(what) {
+        console.warn(what);
+      }
       Module.onRuntimeInitialized = function() {
         try {
           /* Test arbitrary wasm function */

--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -100,12 +100,12 @@ if [ "$DIST" = yes ]; then
       var Module = _Module;
       Module.onAbort = reject;
       Module.print = function(what) {
-        if (console != null) {
+        if (typeof(console) !== 'undefined') {
           console.log(what);
         }
       }
       Module.printErr = function(what) {
-        if (console != null) {
+        if (typeof(console) !== 'undefined') {
           console.warn(what);
         }
       }


### PR DESCRIPTION
This prevents libsodium from breaking when `drop_console=true` is used with uglify. It still shows an `unhandled promise rejection` error on loading. This can either be fixed by overriding `Module.instantiateWasm` with a lot of copied code from emscripten, or making some adjustments to emscripten. See https://github.com/emscripten-core/emscripten/pull/8558 for the progress of an attempt to accomplish the latter :). If it doesn't work out we can always go with option one (or accept that it shows an error..).

Related to https://github.com/jedisct1/libsodium.js/issues/196 and https://github.com/jedisct1/libsodium.js/pull/198