### PR TITLE
Prevent pwhash_scrypt to try to allocate terabytes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -554,7 +554,7 @@ AC_SUBST(CFLAGS_AESNI)
 AC_SUBST(CFLAGS_PCLMUL)
 AC_SUBST(CFLAGS_RDRAND)
 
-AC_CHECK_HEADERS([sys/mman.h sys/random.h intrin.h])
+AC_CHECK_HEADERS([sys/mman.h sys/random.h intrin.h sys/resource.h])
 
 AC_MSG_CHECKING([if _xgetbv() is available])
 AC_LINK_IFELSE(


### PR DESCRIPTION
[`escrypt_kdf_see`](https://github.com/jedisct1/libsodium/blob/515d540524619987443d88c097888ee74d3fd142/src/libsodium/crypto_pwhash/scryptsalsa208sha256/sse/pwhash_scryptsalsa208sha256_sse.c#L377)/[`escrypt_kdf_nosse`](https://github.com/jedisct1/libsodium/blob/515d540524619987443d88c097888ee74d3fd142/src/libsodium/crypto_pwhash/scryptsalsa208sha256/nosse/pwhash_scryptsalsa208sha256_nosse.c#L357) functions call [`alloc_region`](https://github.com/jedisct1/libsodium/blob/515d540524619987443d88c097888ee74d3fd142/src/libsodium/crypto_pwhash/scryptsalsa208sha256/scrypt_platform.c#L45) which calls `mmap`.
[Some invalid pwhash strings use a huge `p` setting](https://github.com/jedisct1/libsodium/blob/515d540524619987443d88c097888ee74d3fd142/test/default/pwhash_scrypt.c#L269-L273). In some case, for example when `vm.overcommit_memory` is enabled, `mmap` doesn't fail quickly, then test process is killed by oomkiller:

```
../../build-aux/test-driver: line 107:   545 Killed                  "$@" > $log_file 2>&1
FAIL: pwhash_scrypt
PASS: pwhash_scrypt_ll
PASS: scalarmult_ed25519
PASS: scalarmult_ristretto255
PASS: siphashx24
PASS: xchacha20
============================================================================
Testsuite summary for libsodium 1.0.17
============================================================================
# TOTAL: 77
# PASS:  76
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0
============================================================================
See test/default/test-suite.log
Please report to https://github.com/jedisct1/libsodium/issues
============================================================================
Makefile:1731: recipe for target 'test-suite.log' failed
make[4]: *** [test-suite.log] Error 1
make[4]: Leaving directory '/root/libsodium/test/default'
Makefile:1837: recipe for target 'check-TESTS' failed
make[3]: *** [check-TESTS] Error 2
make[3]: Leaving directory '/root/libsodium/test/default'
Makefile:2442: recipe for target 'check-am' failed
make[2]: *** [check-am] Error 2
make[2]: Leaving directory '/root/libsodium/test/default'
Makefile:403: recipe for target 'check-recursive' failed
make[1]: *** [check-recursive] Error 1
make[1]: Leaving directory '/root/libsodium/test'
Makefile:514: recipe for target 'check-recursive' failed
make: *** [check-recursive] Error 1
```

Syslog:
```
May 21 06:59:45 seau kernel: [466600.618442] Out of memory: Kill process 545 (lt-pwhash_scryp) score 629 or sacrifice child
May 21 06:59:45 seau kernel: [466600.623319] Killed process 545 (lt-pwhash_scryp) total-vm:137841608784kB, anon-rss:2612924kB, file-rss:4kB, shmem-rss:0kB
May 21 06:59:45 seau kernel: [466601.442047] oom_reaper: reaped process 545 (lt-pwhash_scryp), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
```

This patch set `RLIMIT_AS` allowing `mmap` to fail quickly even when `vm.overcommit_memory` is enabled.