### PR TITLE
Add Open Collective contributors to readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,30 @@ A mailing-list is available to discuss libsodium.
 In order to join, just send a random mail to `sodium-subscribe` {at}
 `pureftpd` {dot} `org`.
 
+## Contributors
+
+### Code Contributors
+
+This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+
+<a href="https://github.com/jedisct1/libsodium/graphs/contributors"><img src="https://opencollective.com/libsodium/contributors.svg?width=890&button=false" /></a>
+
+### Financial Contributors
+
+Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/libsodium/contribute)]
+
+#### Individuals
+
+<a href="https://opencollective.com/libsodium"><img src="https://opencollective.com/libsodium/individuals.svg?width=890"></a>
+
+#### Organizations
+
+Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/libsodium/contribute)]
+
+<a href="https://opencollective.com/libsodium/organization/0/website"><img src="https://opencollective.com/libsodium/organization/0/avatar.svg"></a>
+
+
+
 ## License
 
 [ISC license](https://en.wikipedia.org/wiki/ISC_license).


### PR DESCRIPTION
Hi, I'm making updates for Open Collective. Either you or another core contributor signed this repository up for Open Collective. This pull request adds financial contributors from your Open Collective https://opencollective.com/libsodium ❤️

  What it does:
  - adds a badge to show the latest number of financial contributors
  - adds a banner displaying contributors to the project on GitHub
  - adds a banner displaying all individuals contributing financially on Open Collective
  - adds a section displaying all organizations contributing financially on Open Collective, with their logo and a link to their website

P.S: As with any pull request, feel free to comment or suggest changes.

  Thank you for your great contribution to the Open Source community. You are awesome! 🙌
  And welcome to the Open Collective community! 😊

  Come chat with us in the #opensource channel on https://slack.opencollective.com - great place to ask questions and share best practices with other Open Source sustainers!
  