### PR TITLE
Add a compile-time switch to use secret key values directly

### DIFF
--- a/src/libsodium/crypto_sign/ed25519/ref10/keypair.c
+++ b/src/libsodium/crypto_sign/ed25519/ref10/keypair.c
@@ -15,7 +15,11 @@ crypto_sign_ed25519_seed_keypair(unsigned char *pk, unsigned char *sk,
 {
     ge25519_p3 A;
 
+#ifdef ED25519_NOSHA512SK
+    memcpy(sk, seed, 32);
+#else
     crypto_hash_sha512(sk, seed, 32);
+#endif
     sk[0] &= 248;
     sk[31] &= 127;
     sk[31] |= 64;
@@ -72,7 +76,11 @@ crypto_sign_ed25519_sk_to_curve25519(unsigned char *curve25519_sk,
 {
     unsigned char h[crypto_hash_sha512_BYTES];
 
+#ifdef ED25519_NOSHA512SK
+    memcpy(h, ed25519_sk, 32);
+#else
     crypto_hash_sha512(h, ed25519_sk, 32);
+#endif
     h[0] &= 248;
     h[31] &= 127;
     h[31] |= 64;

--- a/src/libsodium/crypto_sign/ed25519/ref10/sign.c
+++ b/src/libsodium/crypto_sign/ed25519/ref10/sign.c
@@ -74,7 +74,12 @@ _crypto_sign_ed25519_detached(unsigned char *sig, unsigned long long *siglen_p,
 
     _crypto_sign_ed25519_ref10_hinit(&hs, prehashed);
 
+#ifdef ED25519_NOSHA512SK
+    memcpy( az, sk, 32 );
+    memcpy( az + 32, sk, 32 );
+#else
     crypto_hash_sha512(az, sk, 32);
+#endif
 #ifdef ED25519_NONDETERMINISTIC
     _crypto_sign_ed25519_synthetic_r_hv(&hs, nonce /* Z */, az);
 #else


### PR DESCRIPTION
 - The library can be built with `ED25519_NOSHA512SK` defined in order to use secret key values directly without internal sha512 hashing.