### PR TITLE
Workaround for error caused by latest emscripten

### DIFF
--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -116,13 +116,16 @@ if [ "$DIST" = yes ]; then
         }
       };
       Module.useBackupModule = function() {
-        var Module = _Module;
-        Object.keys(Module).forEach(function(k) {
+        var Module = {};
+        $(cat "${PREFIX}/lib/libsodium.asm.tmp.js" | sed 's|use asm||g')
+        Object.keys(_Module).forEach(function(k) {
           if (k !== 'getRandomValue') {
-            delete Module[k];
+            delete _Module[k];
           }
         });
-        $(cat "${PREFIX}/lib/libsodium.asm.tmp.js" | sed 's|use asm||g')
+        Object.keys(Module).forEach(function(k) {
+          _Module[k] = Module[k];
+        });
       };
       $(cat "${PREFIX}/lib/libsodium.wasm.tmp.js")
     }).catch(function() {


### PR DESCRIPTION
For whatever reason, emscripten now throws an error when we try to reuse the same `Module` object between the wasm build and the asm.js build, so the current prod libsodium.js package fails when wasm is unavailable. This resolves the issue.