### PR TITLE
Fix for new emscripten LLVM backend

### DIFF
--- a/dist-build/emscripten.sh
+++ b/dist-build/emscripten.sh
@@ -116,20 +116,28 @@ if [ "$DIST" = yes ]; then
         }
       };
       Module.useBackupModule = function() {
-        var Module = {};
-        $(cat "${PREFIX}/lib/libsodium.asm.tmp.js" | sed 's|use asm||g')
-        Object.keys(_Module).forEach(function(k) {
-          if (k !== 'getRandomValue') {
-            delete _Module[k];
-          }
-        });
-        Object.keys(Module).forEach(function(k) {
-          _Module[k] = Module[k];
+        return new Promise(function(resolve, reject) {
+          var Module = {};
+          Module.onAbort = reject;
+
+          Module.onRuntimeInitialized = function() {
+            Object.keys(_Module).forEach(function(k) {
+              if (k !== 'getRandomValue') {
+                delete _Module[k];
+              }
+            });
+            Object.keys(Module).forEach(function(k) {
+              _Module[k] = Module[k];
+            });
+            resolve();
+          };
+
+          $(cat "${PREFIX}/lib/libsodium.asm.tmp.js" | sed 's|use asm||g')
         });
       };
       $(cat "${PREFIX}/lib/libsodium.wasm.tmp.js")
     }).catch(function() {
-      _Module.useBackupModule();
+      return _Module.useBackupModule();
     });
 EOM
 


### PR DESCRIPTION
Got another libsodium.js fix here. As I [discovered last night](https://github.com/emscripten-core/emscripten/pull/9407#issuecomment-530156742), apparently asm.js with the new LLVM backend no longer initializes synchronously.

This shouldn't matter now unless you're building with emscripten `latest-upstream`, but it sounds like the new backend will become the default pretty soon.