### PR TITLE
add missing initialization in randombytes_random for emscripten

### DIFF
--- a/src/libsodium/randombytes/randombytes.c
+++ b/src/libsodium/randombytes/randombytes.c
@@ -69,6 +69,7 @@ randombytes_random(void)
     randombytes_init_if_needed();
     return implementation->random();
 #else
+    randombytes_stir();
     return EM_ASM_INT_V({
         return Module.getRandomValue();
     });


### PR DESCRIPTION
randombytes_random tried to call Module.getRandomValue without ensuring that it was actually initialized, fixed by calling randombytes_stir which provides this initialization in the emscripten build.