### PR TITLE
Add support for Particle targets

### DIFF
--- a/dist-build/particle.sh
+++ b/dist-build/particle.sh
@@ -1,0 +1,54 @@
+#! /bin/sh
+
+# Build the Particle library structure
+[ -d "builds/particle" ] && rm -rf builds/particle
+mkdir builds/particle
+mkdir builds/particle/examples
+mkdir builds/particle/src
+
+# Copy over the libsodium code
+cp -r src/libsodium builds/particle/src/.
+
+# Build version.h
+sed -i '' 's/@VERSION@/1.0.18/g' builds/particle/src/libsodium/include/sodium/version.h.in
+sed -i '' 's/@SODIUM_LIBRARY_VERSION_MAJOR@/10/g' builds/particle/src/libsodium/include/sodium/version.h.in
+sed -i '' 's/@SODIUM_LIBRARY_VERSION_MINOR@/3/g' builds/particle/src/libsodium/include/sodium/version.h.in
+sed -i '' 's/@SODIUM_LIBRARY_MINIMAL_DEF@//g' builds/particle/src/libsodium/include/sodium/version.h.in
+mv builds/particle/src/libsodium/include/sodium/version.h.in builds/particle/src/libsodium/include/sodium/version.h
+
+# Modify structure to support Particle library format
+cp -r builds/particle/src/libsodium/include/*.h builds/particle/src/.
+cp -r builds/particle/src/libsodium/include/sodium/*.h builds/particle/src/.
+cp -r builds/particle/src/libsodium/include/sodium/private builds/particle/src/.
+# cp builds/particle/inc/sodium/private/*.h builds/particle/inc/.
+rm -r builds/particle/src/libsodium/include
+sed -i '' 's/sodium\///g' builds/particle/src/sodium.h
+
+# Add defines to tops of files so we don't have to use compiler directives
+find ./builds/particle/src -name \*.c -print -exec sed -i '' '1i\
+/*** Defines added by Particle build script ***/ \
+// Prevent warnings associated with building without running autogen.sh \
+#define CONFIGURED 1 \
+\
+// Compiler directives \
+#define HAVE_WEAK_SYMBOLS 1 \
+#define __STDC_LIMIT_MACROS \
+#define __STDC_CONSTANT_MACROS \
+/*** End Particle build script defines ***/ \
+\
+' {} \;
+
+sed -i '' '1i\
+#define RANDOMBYTES_DEFAULT_IMPLEMENTATION
+' builds/particle/src/libsodium/randombytes/randombytes.c;
+
+# Copy our code required for the Particle port
+cp -r particle/port/randombytes_particle.c builds/particle/src/.
+cp -r particle/port/randombytes_internal.h builds/particle/src/.
+cp particle/libsodium.cpp builds/particle/src/.
+cp particle/libsodium.h builds/particle/src/.
+
+# Copy over the the library metadata
+cp LICENSE builds/particle/.
+cp README.markdown builds/particle/README.md
+cp particle/library.properties builds/particle/.

--- a/dist-build/particle.sh
+++ b/dist-build/particle.sh
@@ -1,31 +1,29 @@
 #! /bin/sh
 
+BUILD_ROOT=builds/particle
+INCLUDE_DIR=src/libsodium/include
+
 # Build the Particle library structure
-[ -d "builds/particle" ] && rm -rf builds/particle
-mkdir builds/particle
-mkdir builds/particle/examples
-mkdir builds/particle/src
+[ -d  "$BUILD_ROOT" ] && rm -rf $BUILD_ROOT
+mkdir $BUILD_ROOT
+mkdir $BUILD_ROOT/examples
 
 # Copy over the libsodium code
-cp -r src/libsodium builds/particle/src/.
+cp -r src $BUILD_ROOT/.
 
 # Build version.h
-sed -i '' 's/@VERSION@/1.0.18/g' builds/particle/src/libsodium/include/sodium/version.h.in
-sed -i '' 's/@SODIUM_LIBRARY_VERSION_MAJOR@/10/g' builds/particle/src/libsodium/include/sodium/version.h.in
-sed -i '' 's/@SODIUM_LIBRARY_VERSION_MINOR@/3/g' builds/particle/src/libsodium/include/sodium/version.h.in
-sed -i '' 's/@SODIUM_LIBRARY_MINIMAL_DEF@//g' builds/particle/src/libsodium/include/sodium/version.h.in
-mv builds/particle/src/libsodium/include/sodium/version.h.in builds/particle/src/libsodium/include/sodium/version.h
+sed -i '' 's/@VERSION@/1.0.18/g; s/@SODIUM_LIBRARY_VERSION_MAJOR@/10/g; s/@SODIUM_LIBRARY_VERSION_MINOR@/3/g; s/@SODIUM_LIBRARY_MINIMAL_DEF@//g' $BUILD_ROOT/$INCLUDE_DIR/sodium/version.h.in
+mv $BUILD_ROOT/$INCLUDE_DIR/sodium/version.h.in $BUILD_ROOT/$INCLUDE_DIR/sodium/version.h
 
 # Modify structure to support Particle library format
-cp -r builds/particle/src/libsodium/include/*.h builds/particle/src/.
-cp -r builds/particle/src/libsodium/include/sodium/*.h builds/particle/src/.
-cp -r builds/particle/src/libsodium/include/sodium/private builds/particle/src/.
-# cp builds/particle/inc/sodium/private/*.h builds/particle/inc/.
-rm -r builds/particle/src/libsodium/include
-sed -i '' 's/sodium\///g' builds/particle/src/sodium.h
+cp -r $BUILD_ROOT/$INCLUDE_DIR/*.h $BUILD_ROOT/src/.
+cp -r $BUILD_ROOT/$INCLUDE_DIR/sodium/*.h $BUILD_ROOT/src/.
+cp -r $BUILD_ROOT/$INCLUDE_DIR/sodium/private $BUILD_ROOT/src/.
+rm -r $BUILD_ROOT/$INCLUDE_DIR
+sed -i '' 's/sodium\///g' $BUILD_ROOT/src/sodium.h
 
 # Add defines to tops of files so we don't have to use compiler directives
-find ./builds/particle/src -name \*.c -print -exec sed -i '' '1i\
+find $BUILD_ROOT/src -name \*.c -print -exec sed -i '' '1i\
 /*** Defines added by Particle build script ***/ \
 // Prevent warnings associated with building without running autogen.sh \
 #define CONFIGURED 1 \
@@ -40,15 +38,18 @@ find ./builds/particle/src -name \*.c -print -exec sed -i '' '1i\
 
 sed -i '' '1i\
 #define RANDOMBYTES_DEFAULT_IMPLEMENTATION
-' builds/particle/src/libsodium/randombytes/randombytes.c;
+' $BUILD_ROOT/src/libsodium/randombytes/randombytes.c;
 
 # Copy our code required for the Particle port
-cp -r particle/port/randombytes_particle.c builds/particle/src/.
-cp -r particle/port/randombytes_internal.h builds/particle/src/.
-cp particle/libsodium.cpp builds/particle/src/.
-cp particle/libsodium.h builds/particle/src/.
+cp -r particle/port/randombytes_particle.c $BUILD_ROOT/src/.
+cp -r particle/port/randombytes_internal.h $BUILD_ROOT/src/.
+cp particle/libsodium.cpp $BUILD_ROOT/src/.
+cp particle/libsodium.h $BUILD_ROOT/src/.
 
 # Copy over the the library metadata
-cp LICENSE builds/particle/.
-cp README.markdown builds/particle/README.md
-cp particle/library.properties builds/particle/.
+cp LICENSE $BUILD_ROOT/.
+cp README.markdown $BUILD_ROOT/README.md
+cp particle/library.properties $BUILD_ROOT/.
+
+# Clean up directory a little
+find $BUILD_ROOT/src -name Makefile\* -print -exec rm {} \;

--- a/particle/library.properties
+++ b/particle/library.properties
@@ -1,0 +1,10 @@
+architectures=particle-photon,particle-electron,particle-p1
+author=Frank Denis <libhydrogen@pureftpd.org>
+category=Other
+includes=libsodium.h
+maintainer=Frank Denis <libhydrogen@pureftpd.org>
+name=libsodium
+paragraph=Sodium is a new, easy-to-use software library for encryption, decryption, signatures, password hashing and more
+sentence=A modern, portable, easy to use crypto library
+url=https://github.com/jedisct1/libsodium
+version=1.0.18

--- a/particle/libsodium.cpp
+++ b/particle/libsodium.cpp
@@ -1,0 +1,1 @@
+#include "libsodium.h"

--- a/particle/libsodium.h
+++ b/particle/libsodium.h
@@ -1,0 +1,1 @@
+#include "sodium.h"

--- a/particle/port/randombytes_internal.h
+++ b/particle/port/randombytes_internal.h
@@ -1,0 +1,28 @@
+// Copyright 2017 Espressif Systems (Shanghai) PTE LTD.
+// Modified by Dan Kouba <dan.kouba@particle.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "export.h"
+#include "randombytes.h"
+
+SODIUM_EXPORT
+extern const struct randombytes_implementation randombytes_particle_implementation;
+
+/* Defining RANDOMBYTES_DEFAULT_IMPLEMENTATION here allows us to compile with the ESP32 hardware
+   implementation as the default. No need to call randombytes_set_implementation().
+   Doing it in the header like this is easier than passing it via a -D argument to gcc.
+*/
+#undef RANDOMBYTES_DEFAULT_IMPLEMENTATION
+#define RANDOMBYTES_DEFAULT_IMPLEMENTATION &randombytes_particle_implementation

--- a/particle/port/randombytes_particle.c
+++ b/particle/port/randombytes_particle.c
@@ -1,0 +1,42 @@
+// Copyright 2017 Espressif Systems (Shanghai) PTE LTD
+// Modified by Dan Kouba <dan.kouba@particle.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "rng_hal.h"
+#include "randombytes_internal.h"
+
+static const char *randombytes_particle_implementation_name(void)
+{
+    return "Particle";
+}
+
+static void particle_fill_random(void* data, size_t size) {
+    for (uint32_t* ptr = (uint32_t*)data; (uint32_t*)ptr < (uint32_t*)(data + size); ptr++) {
+        *ptr = HAL_RNG_GetRandomNumber();
+    }
+}
+
+/*
+  Plug the Particle hardware RNG into libsodium's custom RNG support, as per
+  https://download.libsodium.org/doc/advanced/custom_rng.html
+  Note that this RNG is selected by default (see randombytes_default.h), so there
+  is no need to call randombytes_set_implementation().
+*/
+const struct randombytes_implementation randombytes_particle_implementation = {
+    .implementation_name = randombytes_particle_implementation_name,
+    .random = HAL_RNG_GetRandomNumber,
+    .stir = NULL,
+    .uniform = NULL,
+    .buf = particle_fill_random,
+    .close = NULL,
+};


### PR DESCRIPTION
Just want to start a discussion here about the best way to have this support added to the repo.  I have successfully built a version of this library that compiles for Particle targets, but it requires a decent amount of finagling of the directory structure to match what our build system wants, as well as adding some defines to files to avoid custom compiler directives.  I've asked our team to look into adding more customization options to the build system, but until then I'm working with the system as it works today.

I look to the maintainers to suggest a good implementation for "building" the library (more just reformatting) within the existing system.

Otherwise my edits to the random number generator implementation are based on the [ESP32 port](https://github.com/espressif/esp-idf/tree/master/components/libsodium) of this repository.

Interested to hear any ideas!