### PR TITLE
Optimisation to succeed fast when checking signature scalar is reduced.

### DIFF
--- a/src/libsodium/crypto_sign/ed25519/ref10/open.c
+++ b/src/libsodium/crypto_sign/ed25519/ref10/open.c
@@ -28,8 +28,11 @@ _crypto_sign_ed25519_verify_detached(const unsigned char *sig,
         return -1;
     }
 #else
-    if (sc25519_is_canonical(sig + 32) == 0 ||
-        ge25519_has_small_order(sig) != 0) {
+    if (sig[63] & 240 &&
+        sc25519_is_canonical(sig + 32) == 0) {
+      return -1;
+    }
+    if (ge25519_has_small_order(sig) != 0) {
         return -1;
     }
     if (ge25519_is_canonical(pk) == 0 ||


### PR DESCRIPTION
Hi! Thank you for maintaining libsodium!

This provides a minor optimisation for ed25519 signature verification, when used without the -DED25519_COMPAT feature, to strictly check for a fully reduced scalar, `s`, component in variable time by first checking that the most significant *four* bits are unset, and only if any of them are set proceed to the `sc25519_is_canonical` check which performs the full reduction.  This should result in succeeding fast for the check on roughly half of all well-formed, canonicalised signatures.

This is safely backwards compatible with the previous implementation of strict checking for signature scalars.

This is effectively equivalent to https://github.com/dalek-cryptography/ed25519-dalek/pull/99