### PR TITLE
Simplify WASI build using wasienv

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,10 +16,8 @@ jobs:
           curl https://get.wasmer.io -sSfL | sh
         displayName: Install wasmer
       - script: |
-          curl -sL -o wasi-sdk.deb https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-7/wasi-sdk_7.0_amd64.deb
-          sudo dpkg -i wasi-sdk.deb && rm -f wasi-sdk.deb
-          sudo ln -s /opt/wasi-sdk/share/*sysroot* /opt/wasi-sysroot
-        displayName: Install the WASI SDK
+          curl https://raw.githubusercontent.com/wasienv/wasienv/master/install.sh | sh
+        displayName: Install Wasienv
       - script: |
           env WASMER_DIR=${HOME}/.wasmer PATH=${HOME}/.wasmer/bin:/opt/wasi-sdk/bin:${HOME}/.cargo/bin:$PATH dist-build/wasm32-wasi.sh
         displayName: Compile libsodium

--- a/dist-build/wasm32-wasi.sh
+++ b/dist-build/wasm32-wasi.sh
@@ -10,8 +10,15 @@ export PREFIX="$(pwd)/libsodium-wasm32-wasi"
 mkdir -p $PREFIX || exit 1
 
 export CFLAGS="-DED25519_NONDETERMINISTIC=1 -O2"
+export LDFLAGS="-s -Wl,--no-threads"
 
 make distclean > /dev/null
+
+# This is necessary for Frankeinstein Linux systems, where people mix a base
+# system containing old tools (here: old autotools) with backported or
+# hand-compiled recent tools (here: LLVM)
+grep -q -F -- 'wasi' build-aux/config.sub || \
+  sed -i -e 's/-nacl\*)/-nacl*|-wasi)/' build-aux/config.sub
 
 if [ "x$1" = "x--bench" ]; then
   export BENCHMARKS=1

--- a/dist-build/wasm32-wasi.sh
+++ b/dist-build/wasm32-wasi.sh
@@ -1,36 +1,17 @@
 #! /bin/sh
 
-if [ -z "$WASI_LIBC" ]; then
-  for path in /opt/wasi-libc /opt/wasi-sysroot; do
-    if [ -d "$path" ]; then
-      export WASI_LIBC="$path"
-      break
-    fi
-  done
-fi
-if [ -z "$WASI_LIBC" ]; then
-  echo "Set WASI_LIBC to the path to the WASI libc sysroot" >&2
+if ! command -v wasienv >/dev/null; then
+  echo "Wasienv needs to be installed - https://github.com/wasienv/wasienv" >&2
   exit 1
 fi
-
-export PATH="/usr/local/opt/llvm/bin:$PATH"
 
 export PREFIX="$(pwd)/libsodium-wasm32-wasi"
 
 mkdir -p $PREFIX || exit 1
 
-export CC="clang"
-export CFLAGS="-DED25519_NONDETERMINISTIC=1 --target=wasm32-wasi --sysroot=${WASI_LIBC} -O2"
-export LDFLAGS="-s -Wl,--no-threads"
-export NM="llvm-nm"
-export AR="llvm-ar"
-export RANLIB="llvm-ranlib"
-export STRIP="llvm-strip"
+export CFLAGS="-DED25519_NONDETERMINISTIC=1 -O2"
 
 make distclean > /dev/null
-
-grep -q -F -- 'wasi' build-aux/config.sub || \
-  sed -i -e 's/-nacl\*)/-nacl*|-wasi)/' build-aux/config.sub
 
 if [ "x$1" = "x--bench" ]; then
   export BENCHMARKS=1
@@ -43,9 +24,8 @@ else
   export LIBSODIUM_ENABLE_MINIMAL_FLAG=""
 fi
 
-./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
-            --prefix="$PREFIX" --with-sysroot="$WASI_LIBC" \
-            --host=wasm32-wasi \
+wasiconfigure ./configure ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
+            --prefix="$PREFIX" \
             --disable-ssp --disable-shared || exit 1
 
 NPROCESSORS=$(getconf NPROCESSORS_ONLN 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)

--- a/test/default/wasi-test-wrapper.sh
+++ b/test/default/wasi-test-wrapper.sh
@@ -3,24 +3,24 @@
 MAX_MEMORY_TESTS="67108864"
 
 if command -v wasm-opt >/dev/null; then
-  wasm-opt -O4 -o "${1}.tmp" "$1" && mv -f "${1}.tmp" "$1"
+  wasm-opt -O4 -o "${1}.tmp" "$1.wasm" && mv -f "${1}.tmp" "$1.wasm"
 fi
 
 if [ -z "$WASI_RUNTIME" ] || [ "$WASI_RUNTIME" = "wavm" ]; then
   if command -v wavm >/dev/null; then
-    wavm run --abi=wasi "$1" && exit 0
+    wavm run --abi=wasi "$1.wasm" && exit 0
   fi
 fi
 
 if [ -z "$WASI_RUNTIME" ] || [ "$WASI_RUNTIME" = "wasmtime" ]; then
   if command -v wasmtime >/dev/null; then
-    wasmtime -o --dir=. "$1" && exit 0
+    wasmtime -o --dir=. "$1.wasm" && exit 0
   fi
 fi
 
 if [ -z "$WASI_RUNTIME" ] || [ "$WASI_RUNTIME" = "wasmer" ]; then
   if command -v wasmer >/dev/null; then
-    wasmer run "$1" --backend "${WASMER_BACKEND:-cranelift}" --dir=. && exit 0
+    wasmer run "$1.wasm" --backend "${WASMER_BACKEND:-cranelift}" --dir=. && exit 0
   fi
 fi
 
@@ -28,7 +28,7 @@ if [ -z "$WASI_RUNTIME" ] || [ "$WASI_RUNTIME" = "lucet" ]; then
   if command -v lucetc-wasi >/dev/null && command -v lucet-wasi >/dev/null; then
     lucetc-wasi \
       --reserved-size "${MAX_MEMORY_TESTS}" \
-      -o "${1}.so" --opt-level 2 "$1" &&
+      -o "${1}.so" --opt-level 2 "$1.wasm" &&
       lucet-wasi --dir=.:. --max-heap-size "${MAX_MEMORY_TESTS}" "${1}.so" &&
       rm -f "${1}.so" && exit 0
   fi


### PR DESCRIPTION
This PR simplifies the build system using [wasienv](https://github.com/wasienv/wasienv).

This can be incredibly useful to allow contributors to generate the WASI WebAssembly files in their own system easily (since `wasienv` is already available in macOS, Linux and soon Windows!)

Fun fact: [the WASI test wrapper](https://github.com/jedisct1/libsodium/blob/master/test/default/Makefile.am#L507-L509) could also be safely removed (I didn't do it in this PR just in case it's useful to test with more runtimes, but we can add this feature in wasienv if you think it can be useful!)