### PR TITLE
Findsodium.cmake: Support "Generic" platform

### DIFF
--- a/contrib/Findsodium.cmake
+++ b/contrib/Findsodium.cmake
@@ -44,7 +44,7 @@ endif()
 
 # ##############################################################################
 # UNIX
-if(UNIX)
+if(UNIX OR CMAKE_SYSTEM_NAME STREQUAL "Generic")
   # import pkg-config
   find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)


### PR DESCRIPTION
This allows it to work on the Switch toolchain

Taken from here: https://github.com/diasurgical/devilutionX/pull/334/commits/8a5375457e3bb371dc2030a57a6fa0c02efd4177

Credit goes to @glebm