### PR TITLE
Build NuGet package using GitHub Actions (Pt. 2)

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -6,22 +6,24 @@ on:
     - stable
 
 jobs:
+
   build-windows:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Build libsodium
+    - name: buildbase.bat
       run: buildbase.bat ..\vs2019\libsodium.sln 16
       working-directory: builds/msvc/build/
       shell: cmd
     - uses: actions/upload-artifact@v1
       with:
-        name: libsodium-win-x64
+        name: build-win-x64
         path: bin/x64/Release/v142/dynamic/libsodium.dll
     - uses: actions/upload-artifact@v1
       with:
-        name: libsodium-win-x86
+        name: build-win-x86
         path: bin/Win32/Release/v142/dynamic/libsodium.dll
+        
   build-linux-glibc:
     runs-on: ubuntu-latest
     container:
@@ -32,16 +34,21 @@ jobs:
         yum install -q -y centos-release-scl ca-certificates
         yum install -q -y devtoolset-7-gcc*
     - uses: actions/checkout@v1
-    - name: Build libsodium
-      run: |
-        scl enable devtoolset-7 './configure --disable-debug --prefix=$PWD/.libsodium-build'
-        scl enable devtoolset-7 'make && make check'
-        scl enable devtoolset-7 'make install'
-        scl enable devtoolset-7 'strip --strip-all .libsodium-build/lib/libsodium.so'
+    - name: configure
+      run: scl enable devtoolset-7 './configure --disable-debug --prefix=$PWD/.libsodium-build'
+    - name: make
+      run: scl enable devtoolset-7 'make'
+    - name: make check
+      run: scl enable devtoolset-7 'make check'
+    - name: make install
+      run: scl enable devtoolset-7 'make install'
+    - name: strip
+      run: scl enable devtoolset-7 'strip --strip-all .libsodium-build/lib/libsodium.so'
     - uses: actions/upload-artifact@v1
       with:
-        name: libsodium-linux-x64
+        name: build-linux-x64
         path: .libsodium-build/lib/libsodium.so
+        
   build-linux-musl:
     runs-on: ubuntu-latest
     container:
@@ -52,29 +59,38 @@ jobs:
         apk update
         apk add alpine-sdk ca-certificates
     - uses: actions/checkout@v1
-    - name: Build libsodium
-      run: |
-        ./configure --disable-debug --prefix=$PWD/.libsodium-build
-        make && make check
-        make install
-        strip --strip-all .libsodium-build/lib/libsodium.so
+    - name: configure
+      run: ./configure --disable-debug --prefix=$PWD/.libsodium-build
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make install
+      run: make install
+    - name: strip
+      run: strip --strip-all .libsodium-build/lib/libsodium.so
     - uses: actions/upload-artifact@v1
       with:
-        name: libsodium-linux-musl-x64
+        name: build-linux-musl-x64
         path: .libsodium-build/lib/libsodium.so
+        
   build-macos:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Build libsodium
-      run: |
-        ./configure --disable-debug --prefix=$PWD/.libsodium-build
-        make && make check
-        make install
+    - name: configure
+      run: ./configure --disable-debug --prefix=$PWD/.libsodium-build
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make install
+      run: make install
     - uses: actions/upload-artifact@v1
       with:
-        name: libsodium-osx-x64
+        name: build-osx-x64
         path: .libsodium-build/lib/libsodium.dylib
+
   pack:
     runs-on: ubuntu-latest
     needs:
@@ -88,36 +104,60 @@ jobs:
       with:
         dotnet-version: 2.1.607
     - uses: actions/checkout@v1
+    - uses: actions/download-artifact@v1
+      with:
+        name: build-win-x64
+        path: .libsodium-pack/runtimes/win-x64/native/
+    - uses: actions/download-artifact@v1
+      with:
+        name: build-win-x86
+        path: .libsodium-pack/runtimes/win-x86/native/
+    - uses: actions/download-artifact@v1
+      with:
+        name: build-linux-x64
+        path: .libsodium-pack/runtimes/linux-x64/native/
+    - uses: actions/download-artifact@v1
+      with:
+        name: build-linux-musl-x64
+        path: .libsodium-pack/runtimes/linux-musl-x64/native/
+    - uses: actions/download-artifact@v1
+      with:
+        name: build-osx-x64
+        path: .libsodium-pack/runtimes/osx-x64/native/
     - name: Copy files
-      run: |
-        mkdir -p .libsodium-pack/
-        cp AUTHORS ChangeLog LICENSE packaging/dotnet-core/libsodium.pkgproj .libsodium-pack/
-    - uses: actions/download-artifact@v1
-      with:
-        name: libsodium-win-x64
-        path: .libsodium-pack/runtimes/win-x64/native/libsodium.dll
-    - uses: actions/download-artifact@v1
-      with:
-        name: libsodium-win-x86
-        path: .libsodium-pack/runtimes/win-x86/native/libsodium.dll
-    - uses: actions/download-artifact@v1
-      with:
-        name: libsodium-linux-x64
-        path: .libsodium-pack/runtimes/linux-x64/native/libsodium.so
-    - uses: actions/download-artifact@v1
-      with:
-        name: libsodium-linux-musl-x64
-        path: .libsodium-pack/runtimes/linux-musl-x64/native/libsodium.so
-    - uses: actions/download-artifact@v1
-      with:
-        name: libsodium-osx-x64
-        path: .libsodium-pack/runtimes/osx-x64/native/libsodium.dylib
-    - name: Pack
+      run: cp AUTHORS ChangeLog LICENSE packaging/dotnet-core/libsodium.pkgproj .libsodium-pack/
+    - name: Create NuGet package
       run: dotnet pack .libsodium-pack/libsodium.pkgproj
       env:
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     - uses: actions/upload-artifact@v1
       with:
-        name: libsodium.1.0.18.nupkg
+        name: nuget-package
         path: .libsodium-pack/libsodium.1.0.18.nupkg
+
+  test-ubuntu18_04:
+    runs-on: ubuntu-latest
+    needs: 
+    - pack
+    container:
+      image: mcr.microsoft.com/dotnet/core/sdk:3.1-bionic
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/download-artifact@v1
+      with:
+        name: nuget-package
+        path: .libsodium-pack/
+    - name: dotnet new
+      run: dotnet new console -n Tests -o .libsodium-test/
+    - name: dotnet add package libsodium
+      run: dotnet add .libsodium-test/Tests.csproj package libsodium -s $PWD/.libsodium-pack
+    - name: Copy files
+      run: cp -f packaging/dotnet-core/test.cs .libsodium-test/Program.cs
+    - name: dotnet run
+      run: dotnet run
+      working-directory: .libsodium-test/

--- a/packaging/dotnet-core/libsodium.pkgproj
+++ b/packaging/dotnet-core/libsodium.pkgproj
@@ -31,7 +31,11 @@
     <Content Include="LICENSE" PackagePath="" />
     <Content Include="AUTHORS" PackagePath="" />
     <Content Include="ChangeLog" PackagePath="" />
-    <Content Include="runtimes\**\*.*" PackagePath="runtimes\" />
+    <Content Include="runtimes/win-x64/native/libsodium.dll" PackagePath="runtimes/win-x64/native/" />
+    <Content Include="runtimes/win-x86/native/libsodium.dll" PackagePath="runtimes/win-x86/native/" />
+    <Content Include="runtimes/linux-x64/native/libsodium.so" PackagePath="runtimes/linux-x64/native/" />
+    <Content Include="runtimes/linux-musl-x64/native/libsodium.so" PackagePath="runtimes/linux-musl-x64/native/" />
+    <Content Include="runtimes/osx-x64/native/libsodium.dylib" PackagePath="runtimes/osx-x64/native/" />
   </ItemGroup>
 
 </Project>

--- a/packaging/dotnet-core/test.cs
+++ b/packaging/dotnet-core/test.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.InteropServices;
+
+internal static class Program
+{
+    internal static int Main()
+    {
+        Console.WriteLine("sodium_version_string: {0}", Marshal.PtrToStringAnsi(sodium_version_string()));
+        Console.WriteLine("sodium_library_version_major: {0}", sodium_library_version_major());
+        Console.WriteLine("sodium_library_version_minor: {0}", sodium_library_version_minor());
+        Console.WriteLine("sodium_library_minimal: {0}", sodium_library_minimal());
+        int error = sodium_init();
+        Console.WriteLine("sodium_init: {0}", error);
+        if (error == 0)
+        {
+            randombytes_buf(out ulong buf, (UIntPtr)sizeof(ulong));
+            Console.WriteLine("randombytes_buf: 0x'{0:X8}'", buf);
+            Console.WriteLine("crypto_aead_aes256gcm_is_available: {0}", crypto_aead_aes256gcm_is_available());
+        }
+        return error == 0 ? 0 : 1;
+    }
+
+    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int crypto_aead_aes256gcm_is_available();
+
+    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    private static extern void randombytes_buf(out ulong buf, UIntPtr size);
+
+    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int sodium_init();
+
+    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int sodium_library_version_major();
+
+    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int sodium_library_minimal();
+
+    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int sodium_library_version_minor();
+
+    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    private static extern IntPtr sodium_version_string();
+}


### PR DESCRIPTION
I should have tested this a bit more...

This pull request fixes #909 and adds a basic sanity check.

@jedisct1: There is now an artifact created called "nuget-package". Downloading this results in a .zip file that contains the .nupkg file (libsodium.1.0.18.nupkg at the moment) that can be uploaded to nuget.org.

If the build steps look good to you, it would be great if you could upload libsodium.1.0.18.nupkg to nuget.org.