### PR TITLE
Avoid memmove() call when buffers are already the same.

### DIFF
--- a/src/libsodium/crypto_secretbox/crypto_secretbox_easy.c
+++ b/src/libsodium/crypto_secretbox/crypto_secretbox_easy.c
@@ -101,9 +101,9 @@ crypto_secretbox_open_detached(unsigned char *m, const unsigned char *c,
     if (m == NULL) {
         return 0;
     }
-    if (((uintptr_t) c >= (uintptr_t) m &&
+    if (((uintptr_t) c > (uintptr_t) m &&
          (uintptr_t) c - (uintptr_t) m < clen) ||
-        ((uintptr_t) m >= (uintptr_t) c &&
+        ((uintptr_t) m > (uintptr_t) c &&
          (uintptr_t) m - (uintptr_t) c < clen)) { /* LCOV_EXCL_LINE */
         memmove(m, c, clen);
         c = m;

--- a/src/libsodium/crypto_secretbox/xchacha20poly1305/secretbox_xchacha20poly1305.c
+++ b/src/libsodium/crypto_secretbox/xchacha20poly1305/secretbox_xchacha20poly1305.c
@@ -108,9 +108,9 @@ crypto_secretbox_xchacha20poly1305_open_detached(unsigned char *m,
     if (m == NULL) {
         return 0;
     }
-    if (((uintptr_t) c >= (uintptr_t) m &&
+    if (((uintptr_t) c > (uintptr_t) m &&
          (uintptr_t) c - (uintptr_t) m < clen) ||
-        ((uintptr_t) m >= (uintptr_t) c &&
+        ((uintptr_t) m > (uintptr_t) c &&
          (uintptr_t) m - (uintptr_t) c < clen)) { /* LCOV_EXCL_LINE */
         memmove(m, c, clen);
         c = m;


### PR DESCRIPTION
This completes the work started in commit
fbe3eb265fc1e93c74bf6110615176d1fb432b04