### PR TITLE
Fix build config for *-eabihf targets

### DIFF
--- a/configure
+++ b/configure
@@ -5194,7 +5194,7 @@ fi
 
 
 case $host_os in #(
-  mingw*|cygwin*|msys|eabi) :
+  mingw*|cygwin*|msys|eabi*) :
     enable_pie="no" ;; #(
   *) :
      ;;
@@ -7008,7 +7008,7 @@ fi
 
 
 case $host_os in #(
-  cygwin*|mingw*|msys|pw32*|cegcc*|eabi) :
+  cygwin*|mingw*|msys|pw32*|cegcc*|eabi*) :
       ;; #(
   *) :
 
@@ -7439,7 +7439,7 @@ fi
 esac
 
 case $host_os in #(
-  cygwin*|mingw*|msys|pw32*|cegcc*|eabi) :
+  cygwin*|mingw*|msys|pw32*|cegcc*|eabi*) :
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fno-asynchronous-unwind-tables" >&5
 $as_echo_n "checking whether C compiler accepts -fno-asynchronous-unwind-tables... " >&6; }
@@ -7559,7 +7559,7 @@ if test "x$enable_ssp" != "xno"; then :
 
 
 case $host_os in #(
-  cygwin*|mingw*|msys|pw32*|cegcc*|haiku|none|eabi) :
+  cygwin*|mingw*|msys|pw32*|cegcc*|haiku|none|eabi*) :
       ;; #(
   *) :
 

--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ AC_ARG_ENABLE(pie,
 [AS_HELP_STRING(--disable-pie,Do not produce position independent executables)],
  enable_pie=$enableval, enable_pie="maybe")
 
-AS_CASE([$host_os], [mingw*|cygwin*|msys|eabi], [enable_pie="no"])
+AS_CASE([$host_os], [mingw*|cygwin*|msys|eabi*], [enable_pie="no"])
 
 AC_ARG_ENABLE(blocking-random,
 [AS_HELP_STRING(--enable-blocking-random,Enable this switch only if /dev/urandom is totally broken on the target platform)],
@@ -223,7 +223,7 @@ AS_CASE([$host_os], [linux-gnu], [AX_ADD_FORTIFY_SOURCE], [ ])
 AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],
   [CFLAGS="$CFLAGS -fvisibility=hidden"])
 
-AS_CASE([$host_os], [cygwin*|mingw*|msys|pw32*|cegcc*|eabi], [ ], [
+AS_CASE([$host_os], [cygwin*|mingw*|msys|pw32*|cegcc*|eabi*], [ ], [
   AX_CHECK_COMPILE_FLAG([-fPIC], [CFLAGS="$CFLAGS -fPIC"])
 ])
 
@@ -276,7 +276,7 @@ AS_CASE([$host_os],
   ])
 
 AS_CASE([$host_os],
-  [cygwin*|mingw*|msys|pw32*|cegcc*|eabi], [
+  [cygwin*|mingw*|msys|pw32*|cegcc*|eabi*], [
     AX_CHECK_COMPILE_FLAG([-fno-asynchronous-unwind-tables], [
       [CFLAGS="$CFLAGS -fno-asynchronous-unwind-tables"]
     ])
@@ -302,7 +302,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
 AS_IF([test "x$enable_ssp" != "xno"],[
 
 AS_CASE([$host_os],
-  [cygwin*|mingw*|msys|pw32*|cegcc*|haiku|none|eabi], [ ],
+  [cygwin*|mingw*|msys|pw32*|cegcc*|haiku|none|eabi*], [ ],
   [*], [
     AX_CHECK_COMPILE_FLAG([-fstack-protector], [
       AX_CHECK_LINK_FLAG([-fstack-protector],


### PR DESCRIPTION
Hey thanks for the help looking at / improving this!

As the `eabi` match appears to be derived from the `HOST` argument this needs to cover both `arm-none-eabi` and `arm-none-eabihf` (though presumably not `arm-linux-gnueabi` for instance).

I've expanded it from `eabi` to `eabi*` as with other listed options, though `eabi|eabihf` would be equally applicable if it is preferred.

Related to: https://github.com/sodiumoxide/sodiumoxide/issues/363
Initial commit: https://github.com/jedisct1/libsodium/commit/e04088d0b29f3d9f4575cb6d9c16b93a00bd1041