### PR TITLE
Fix: make only a single call to 'xcodebuild -create-xcframework'

### DIFF
--- a/dist-build/ios.sh
+++ b/dist-build/ios.sh
@@ -261,13 +261,19 @@ echo "Creating Clibsodium.xcframework..."
 
 rm -rf "${PREFIX}/Clibsodium.xcframework"
 
-for f in ios ios-simulators watchos watchos-simulators catalyst; do
-  echo "> ${f}"
-  xcodebuild -create-xcframework \
-    -library "${PREFIX}/${f}/lib/libsodium.a" \
-    -headers "${PREFIX}/${f}/include" \
-    -output "${PREFIX}/Clibsodium.xcframework" >/dev/null
-done
+xcodebuild -create-xcframework \
+  -library "${PREFIX}/ios/lib/libsodium.a" \
+  -headers "${PREFIX}/ios/include" \
+  -library "${PREFIX}/ios-simulators/lib/libsodium.a" \
+  -headers "${PREFIX}/ios-simulators/include" \
+  -library "${PREFIX}/watchos/lib/libsodium.a" \
+  -headers "${PREFIX}/watchos/include" \
+  -library "${PREFIX}/watchos-simulators/lib/libsodium.a" \
+  -headers "${PREFIX}/watchos-simulators/include" \
+  -library "${PREFIX}/catalyst/lib/libsodium.a" \
+  -headers "${PREFIX}/catalyst/include" \
+  -output "${PREFIX}/Clibsodium.xcframework"
+
 
 ls -ld -- "$PREFIX"
 ls -l -- "$PREFIX"


### PR DESCRIPTION
`xcodebuild -create-xcframework` writes manifest data to the root of the XCFramework in Info.plist. Although calling it repeatedly (instead of making a single call) does add the new subfolders to the bundle without wiping the previous ones, it _doesn't_ merge the old + new manifest data together; instead, each subsequent call clobbers any existing Info.plist. As a result, the only way to use it is to make a single call, and include all of the library+header pairs at once.

Meanwhile: Is there a plan to switch swift-sodium to use an embedded XCFramework instead of a plain .a library? This would enable its use in Catalyst-based projects. There appears to be [a limitation in the current version of Cocoapods](https://github.com/CocoaPods/CocoaPods/issues/9528) that prevents it from working with a `.a`-based XCFramework, but that is supposed to be fixed in 1.10 (and current development versions).