### PR TITLE
Add a muse configuration

### DIFF
--- a/.muse/config.toml
+++ b/.muse/config.toml
@@ -1,0 +1,2 @@
+setup = ".muse/setup.sh"
+build = "make"

--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#! /bin/sh
 ./autogen.sh -s
 env CPPFLAGS="-DDEV_MODE=1" ./configure --disable-dependency-tracking

--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+./autogen.sh -s
+env CPPFLAGS="-DDEV_MODE=1" ./configure --disable-dependency-tracking


### PR DESCRIPTION
@jedisct1 Hello, I work on Muse Dev and saw a job running on libsodium.  First let me say I'm very much a fan of libsodium and super excited to see it show up in the logs.  I've fixed a security issue in libsodium bindings, saltine, and used an SMT solver to prove libsodium's swapped SHA2 implementations were functionally identical (some years ago).  That second one was actually done in CI and as a exploratory tool in MuseDev.  So thank you for providing such a useful library.

This pull request borrows some of the build commands used in travis and provides them via a Muse configuration file and setup script.  It allows Muse to successfully build a compilation database [and thus run infer on the project](https://staging.muse.dev/result/TomMD/libsodium/01EEK1KM33RZVHEXPT9XMV54R6?tab=results).  To run Muse automatically on all PRs then this merge and installing the GitHub app will do it.

We're sensitive to the fact configuration required manual effort and are looking for ways to automate detection and execution of the build, even when the steps and flags are non-trivial.  If you have any thoughts there or on the rest of the system then I'd be happy to chat any time.