### PR TITLE
DragonFlyBSD supports getrandom too since 5.7, 5.8 is the

### DIFF
--- a/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c
+++ b/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c
@@ -30,9 +30,10 @@
 #   define HAVE_LINUX_COMPATIBLE_GETRANDOM
 #  endif
 # endif
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 # include <sys/param.h>
-# if defined(__FreeBSD_version) && __FreeBSD_version >= 1200000
+# if (defined(__FreeBSD_version) && __FreeBSD_version >= 1200000) || \
+     (defined(__DragonFly_version) && __DragonFly_version >= 500700)
 #  define HAVE_LINUX_COMPATIBLE_GETRANDOM
 # endif
 #endif


### PR DESCRIPTION
 actual stable release.