### PR TITLE
Error from argon2_hash() during verify propagated.

### DIFF
--- a/src/libsodium/crypto_pwhash/argon2/argon2.c
+++ b/src/libsodium/crypto_pwhash/argon2/argon2.c
@@ -256,7 +256,7 @@ argon2_verify(const char *encoded, const void *pwd, const size_t pwdlen,
     free(ctx.ad);
     free(ctx.salt);
 
-    if (ret != ARGON2_OK || sodium_memcmp(out, ctx.out, ctx.outlen) != 0) {
+    if (ret == ARGON2_OK && sodium_memcmp(out, ctx.out, ctx.outlen) != 0) {
         ret = ARGON2_VERIFY_MISMATCH;
     }
     free(out);


### PR DESCRIPTION
When verifying a password, argon2_verify() calls argon2_hash() to recreate the hash to compare. The recreated hash is then compared to the stored hash.

However, argon2_hash() could fail, e.g., because of an out-of-memory condition. In this case, the existing code will return ARGON2_VERIFY_MISMATCH instead of the error reported by argon2_hash(). This will cause the client code of libsodium to incorrectly believe the password did not match and report that back to the user.

With this patch, argon2_verify() will propagate the error from argon2_hash() if it fails. Only if it argon2_hash() succeeds, the existing hash and the recreated hash will be compared and if not matching ARGON2_VERIFY_MISMATCH will be returned.