### PR TITLE
Add sodium_finalize()

### DIFF
--- a/src/libsodium/include/sodium/core.h
+++ b/src/libsodium/include/sodium/core.h
@@ -12,6 +12,9 @@ SODIUM_EXPORT
 int sodium_init(void)
             __attribute__ ((warn_unused_result));
 
+SODIUM_EXPORT
+void sodium_finalize(void);
+
 /* ---- */
 
 SODIUM_EXPORT


### PR DESCRIPTION
`sodium_crit_enter()` lazily initializes a critical section on Windows
but that critical section is never deleted (`DeleteCriticalSection()`).
This is not an issue per se, since the critical section is released on
process termination, but Application Verifier complains about that
("Unloading DLL containing an active critical section.")

There is no way yet to delete this critical section, since it is held
in a file static variable, and there is no API to delete it.  Thus,
I suggest to introduce `sodium_finalize()` which can be called by
clients to delete the critical section on process termination.

The new API should be available on all supported platforms, although
I don't know whether similar issues exists elsewhere.  For now, it does
nothing on other platforms than Windows.

---

For PHP's sodium extension, it could be used like:
````.diff
 ext/sodium/libsodium.c | 1 +
 1 file changed, 1 insertion(+)

diff --git a/ext/sodium/libsodium.c b/ext/sodium/libsodium.c
index abde3b8994..2eefd569a1 100644
--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -655,6 +655,7 @@ PHP_MINIT_FUNCTION(sodium)
 PHP_MSHUTDOWN_FUNCTION(sodium)
 {
 	randombytes_close();
+	sodium_finalize();
 	return SUCCESS;
 }
 ````