### PR TITLE
Delete critical section on DLL_PROCESS_DETACH

### DIFF
--- a/src/libsodium/sodium/core.c
+++ b/src/libsodium/sodium/core.c
@@ -214,3 +214,16 @@ sodium_set_misuse_handler(void (*handler)(void))
     }
     return 0;
 }
+
+#ifdef _WIN32
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
+    switch (fdwReason) {
+        case DLL_PROCESS_DETACH:
+            if (_sodium_lock_initialized == 2) {
+                DeleteCriticalSection(&_sodium_lock);
+            }
+            break;
+    }
+    return TRUE;
+}
+#endif


### PR DESCRIPTION
To explicitly release all allocated resources on shutdown on Windows,
we delete the critical section on `DLL_PROCESS_DETACH`.  We do not
employ any locking to avoid any potential deadlock.  In case of normal
DLL unloading there is no need to, and in case of forced unloading all
bets are likely off anyway.