### PR TITLE
Define randombytes_set_implementation argument to be const

### DIFF
--- a/src/libsodium/include/sodium/randombytes.h
+++ b/src/libsodium/include/sodium/randombytes.h
@@ -53,7 +53,7 @@ SODIUM_EXPORT
 int randombytes_close(void);
 
 SODIUM_EXPORT
-int randombytes_set_implementation(randombytes_implementation *impl)
+int randombytes_set_implementation(const randombytes_implementation *impl)
             __attribute__ ((nonnull));
 
 SODIUM_EXPORT

--- a/src/libsodium/randombytes/randombytes.c
+++ b/src/libsodium/randombytes/randombytes.c
@@ -112,7 +112,7 @@ randombytes_init_if_needed(void)
 }
 
 int
-randombytes_set_implementation(randombytes_implementation *impl)
+randombytes_set_implementation(const randombytes_implementation *impl)
 {
     implementation = impl;
     return 0;


### PR DESCRIPTION
Discourage developers from creating writable function pointers. If someone insists on having their implementation spec be writable, it's easy to cast to const, but if someone does the right thing and defines it as a const, it's harder to go the other way.