### PR TITLE
Add linux-arm64 binary to the generated nuget package

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -48,6 +48,50 @@ jobs:
       with:
         name: build-linux-x64
         path: .libsodium-build/lib/libsodium.so
+
+        
+  build-linux-glibc-arm64:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Set up build environment
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+
+        cat <<-EOF | sudo tee /etc/apt/sources.list.d/arm64.list >/dev/null
+        deb [arch=arm64] http://ports.ubuntu.com/ focal main restricted
+        deb [arch=arm64] http://ports.ubuntu.com/ focal-updates main restricted
+        deb [arch=arm64] http://ports.ubuntu.com/ focal universe
+        deb [arch=arm64] http://ports.ubuntu.com/ focal-updates universe
+        deb [arch=arm64] http://ports.ubuntu.com/ focal multiverse
+        deb [arch=arm64] http://ports.ubuntu.com/ focal-updates multiverse
+        deb [arch=arm64] http://ports.ubuntu.com/ focal-backports main restricted universe multiverse
+        EOF
+
+        sudo sed -i 's/deb h/deb [arch=amd64] h/g' /etc/apt/sources.list
+
+        sudo dpkg --add-architecture arm64
+
+        sudo apt-get update && sudo apt-get install -y build-essential qemu-user qemu-user-static gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libstdc++6:arm64
+
+    - uses: actions/checkout@v1
+    - name: configure
+      run: ./configure --disable-debug --prefix=$PWD/.libsodium-build --host=aarch64-linux-gnu
+    - name: make
+      run: make -j $(nproc)
+      
+    - name: make check
+      run: |
+        make check
+
+    - name: make install
+      run: make install
+
+    - name: strip
+      run: aarch64-linux-gnu-strip --strip-all .libsodium-build/lib/libsodium.so
+    - uses: actions/upload-artifact@v1
+      with:
+        name: build-linux-arm64
+        path: .libsodium-build/lib/libsodium.so        
         
   build-linux-musl:
     runs-on: ubuntu-latest
@@ -96,6 +140,7 @@ jobs:
     needs:
     - build-windows
     - build-linux-glibc
+    - build-linux-glibc-arm64
     - build-linux-musl
     - build-macos
     container:
@@ -118,6 +163,10 @@ jobs:
       with:
         name: build-linux-x64
         path: .libsodium-pack/runtimes/linux-x64/native/
+    - uses: actions/download-artifact@v1
+      with:
+        name: build-linux-arm64
+        path: .libsodium-pack/runtimes/linux-arm64/native/
     - uses: actions/download-artifact@v1
       with:
         name: build-linux-musl-x64

--- a/packaging/dotnet-core/libsodium.pkgproj
+++ b/packaging/dotnet-core/libsodium.pkgproj
@@ -28,6 +28,7 @@
     <Content Include="runtimes/win-x64/native/libsodium.dll" PackagePath="runtimes/win-x64/native/" />
     <Content Include="runtimes/win-x86/native/libsodium.dll" PackagePath="runtimes/win-x86/native/" />
     <Content Include="runtimes/linux-x64/native/libsodium.so" PackagePath="runtimes/linux-x64/native/" />
+    <Content Include="runtimes/linux-arm64/native/libsodium.so" PackagePath="runtimes/linux-arm64/native/" />
     <Content Include="runtimes/linux-musl-x64/native/libsodium.so" PackagePath="runtimes/linux-musl-x64/native/" />
     <Content Include="runtimes/osx-x64/native/libsodium.dylib" PackagePath="runtimes/osx-x64/native/" />
   </ItemGroup>


### PR DESCRIPTION
Uses cross-compilation to run make; make check uses qemu to execute the tests on virtualised ARM64.

Note that I couldn't get the qemu-run make check to execute when running inside a docker container, so the arm64 job runs directly on the runner.

I've tested this process works on stable (see last run at https://github.com/enclave-alistair/libsodium/actions/runs/874111971).

Once the existing Autoconf build failure on master is resolved, I will test on master.


