### PR TITLE
Define randombytes_set_implementation argument to be const.

### DIFF
--- a/src/libsodium/include/sodium/randombytes.h
+++ b/src/libsodium/include/sodium/randombytes.h
@@ -53,7 +53,7 @@ SODIUM_EXPORT
 int randombytes_close(void);
 
 SODIUM_EXPORT
-int randombytes_set_implementation(randombytes_implementation *impl)
+int randombytes_set_implementation(const randombytes_implementation *impl)
             __attribute__ ((nonnull));
 
 SODIUM_EXPORT

--- a/src/libsodium/randombytes/randombytes.c
+++ b/src/libsodium/randombytes/randombytes.c
@@ -112,7 +112,7 @@ randombytes_init_if_needed(void)
 }
 
 int
-randombytes_set_implementation(randombytes_implementation *impl)
+randombytes_set_implementation(const randombytes_implementation *impl)
 {
     implementation = impl;
     return 0;


### PR DESCRIPTION
Allow applications to use const vtables. The promise here is that libsodium will not modify the application's vtable. Of course, libsodium does not and will not modify the application provided vtable, so this is just being explicit about an existing property. Applications providing non-const vtable pointers will have those pointers implicitly coerced to const in the function invocation, without any code changes in the application.

(Without this change, applications with const vtables must use kludges like casting-through-uintptr_t to strip the const qualifier from the vtable pointer.)