### PR TITLE
Adding linux-arm support for the .net build

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -92,6 +92,49 @@ jobs:
         name: build-linux-arm64
         path: .libsodium-build/lib/libsodium.so
 
+  build-linux-glibc-arm:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Set up build environment
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+
+        cat <<-EOF | sudo tee /etc/apt/sources.list.d/armhf.list >/dev/null
+        deb [arch=armhf] http://ports.ubuntu.com/ focal main restricted
+        deb [arch=armhf] http://ports.ubuntu.com/ focal-updates main restricted
+        deb [arch=armhf] http://ports.ubuntu.com/ focal universe
+        deb [arch=armhf] http://ports.ubuntu.com/ focal-updates universe
+        deb [arch=armhf] http://ports.ubuntu.com/ focal multiverse
+        deb [arch=armhf] http://ports.ubuntu.com/ focal-updates multiverse
+        deb [arch=armhf] http://ports.ubuntu.com/ focal-backports main restricted universe multiverse
+        EOF
+
+        sudo sed -i 's/deb h/deb [arch=amd64] h/g' /etc/apt/sources.list
+
+        sudo dpkg --add-architecture armhf
+
+        sudo apt-get update && sudo apt-get install -y build-essential qemu-user qemu-user-static gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libstdc++6:armhf
+
+    - uses: actions/checkout@v1
+    - name: configure
+      run: ./configure --disable-debug --prefix=$PWD/.libsodium-build --host=arm-linux-gnueabihf
+    - name: make
+      run: make -j $(nproc)
+      
+    - name: make check
+      run: |
+        make check
+
+    - name: make install
+      run: make install
+
+    - name: strip
+      run: arm-linux-gnueabihf-strip --strip-all .libsodium-build/lib/libsodium.so
+    - uses: actions/upload-artifact@v1
+      with:
+        name: build-linux-arm
+        path: .libsodium-build/lib/libsodium.so       
+        
   build-linux-musl:
     runs-on: ubuntu-latest
     container:
@@ -166,6 +209,10 @@ jobs:
       with:
         name: build-linux-arm64
         path: .libsodium-pack/runtimes/linux-arm64/native/
+    - uses: actions/download-artifact@v1
+      with:
+        name: build-linux-arm
+        path: .libsodium-pack/runtimes/linux-arm/native/
     - uses: actions/download-artifact@v1
       with:
         name: build-linux-musl-x64

--- a/packaging/dotnet-core/libsodium.pkgproj
+++ b/packaging/dotnet-core/libsodium.pkgproj
@@ -29,6 +29,7 @@
     <Content Include="runtimes/win-x86/native/libsodium.dll" PackagePath="runtimes/win-x86/native/" />
     <Content Include="runtimes/linux-x64/native/libsodium.so" PackagePath="runtimes/linux-x64/native/" />
     <Content Include="runtimes/linux-arm64/native/libsodium.so" PackagePath="runtimes/linux-arm64/native/" />
+    <Content Include="runtimes/linux-arm/native/libsodium.so" PackagePath="runtimes/linux-arm/native/" />
     <Content Include="runtimes/linux-musl-x64/native/libsodium.so" PackagePath="runtimes/linux-musl-x64/native/" />
     <Content Include="runtimes/osx-x64/native/libsodium.dylib" PackagePath="runtimes/osx-x64/native/" />
   </ItemGroup>


### PR DESCRIPTION
As requested in #1067, generate an armhf cross-compile so we have `linux-arm` support and `linux-arm64` at the same time.

