### PR TITLE
Add multi-plat nuget package testing

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -16,11 +16,11 @@ jobs:
       run: buildbase.bat ..\vs2019\libsodium.sln 16
       working-directory: builds/msvc/build/
       shell: cmd
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: build-win-x64
         path: bin/x64/Release/v142/dynamic/libsodium.dll
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: build-win-x86
         path: bin/Win32/Release/v142/dynamic/libsodium.dll
@@ -44,7 +44,7 @@ jobs:
       run: make install
     - name: strip
       run: strip --strip-all .libsodium-build/lib/libsodium.so
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: build-linux-x64
         path: .libsodium-build/lib/libsodium.so
@@ -87,7 +87,7 @@ jobs:
 
     - name: strip
       run: aarch64-linux-gnu-strip --strip-all .libsodium-build/lib/libsodium.so
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: build-linux-arm64
         path: .libsodium-build/lib/libsodium.so
@@ -130,7 +130,7 @@ jobs:
 
     - name: strip
       run: arm-linux-gnueabihf-strip --strip-all .libsodium-build/lib/libsodium.so
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: build-linux-arm
         path: .libsodium-build/lib/libsodium.so
@@ -155,7 +155,7 @@ jobs:
       run: make install
     - name: strip
       run: strip --strip-all .libsodium-build/lib/libsodium.so
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: build-linux-musl-x64
         path: .libsodium-build/lib/libsodium.so
@@ -172,7 +172,7 @@ jobs:
       run: make check
     - name: make install
       run: make install
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: build-osx-x64
         path: .libsodium-build/lib/libsodium.dylib
@@ -182,6 +182,7 @@ jobs:
     needs:
     - build-windows
     - build-linux-glibc
+    - build-linux-glibc-arm
     - build-linux-glibc-arm64
     - build-linux-musl
     - build-macos
@@ -193,31 +194,31 @@ jobs:
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: build-win-x64
         path: .libsodium-pack/runtimes/win-x64/native/
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: build-win-x86
         path: .libsodium-pack/runtimes/win-x86/native/
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: build-linux-x64
         path: .libsodium-pack/runtimes/linux-x64/native/
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: build-linux-arm64
         path: .libsodium-pack/runtimes/linux-arm64/native/
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: build-linux-arm
         path: .libsodium-pack/runtimes/linux-arm/native/
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: build-linux-musl-x64
         path: .libsodium-pack/runtimes/linux-musl-x64/native/
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: build-osx-x64
         path: .libsodium-pack/runtimes/osx-x64/native/
@@ -225,24 +226,24 @@ jobs:
       run: cp AUTHORS ChangeLog LICENSE packaging/dotnet-core/libsodium.pkgproj .libsodium-pack/
     - name: Create NuGet package
       run: dotnet pack -c Release .libsodium-pack/libsodium.pkgproj
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: nuget-package
-        path: .libsodium-pack/bin/Release/libsodium.1.0.18.nupkg
+        path: .libsodium-pack/bin/Release/*.nupkg
 
-  test-ubuntu20_04:
+  build-test-binaries:
     runs-on: ubuntu-latest
     needs:
     - pack
     container:
-      image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
+      image: mcr.microsoft.com/dotnet/sdk:5.0
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: nuget-package
         path: .libsodium-pack/
@@ -252,6 +253,64 @@ jobs:
       run: dotnet add .libsodium-test/Tests.csproj package libsodium -s $PWD/.libsodium-pack
     - name: Copy files
       run: cp -f packaging/dotnet-core/test.cs .libsodium-test/Program.cs
-    - name: dotnet run
-      run: dotnet run
+    - name: dotnet publish linux-x64
+      run: dotnet publish -c Release -r linux-x64 --self-contained true -p:PublishTrimmed=true
       working-directory: .libsodium-test/
+    - name: dotnet publish linux-arm
+      run: dotnet publish -c Release -r linux-arm --self-contained true -p:PublishTrimmed=true
+      working-directory: .libsodium-test/
+    - name: dotnet publish linux-arm64
+      run: dotnet publish -c Release -r linux-arm64 --self-contained true -p:PublishTrimmed=true
+      working-directory: .libsodium-test/
+    - name: Move Build Output
+      run: |
+        mkdir .libsodium-builds
+        mv .libsodium-test/bin/Release/net5.0/linux-arm/publish .libsodium-builds/linux-arm        
+        mv .libsodium-test/bin/Release/net5.0/linux-arm64/publish .libsodium-builds/linux-arm64
+        mv .libsodium-test/bin/Release/net5.0/linux-x64/publish .libsodium-builds/linux-x64
+    - uses: actions/upload-artifact@v2
+      with:
+        name: test-builds
+        path: .libsodium-builds/*
+
+  run-test-binaries:
+    runs-on: ubuntu-20.04
+    needs:
+    - build-test-binaries
+    env:
+      DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
+    strategy:
+      matrix:
+        arch: [x64, arm, arm64]
+    steps:
+    - name: Set up build environment
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+
+        cat <<-EOF | sudo tee /etc/apt/sources.list.d/multiarch.list >/dev/null
+        deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal main restricted
+        deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-updates main restricted
+        deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal universe
+        deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-updates universe
+        deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal multiverse
+        deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-updates multiverse
+        deb [arch=armhf,arm64] http://ports.ubuntu.com/ focal-backports main restricted universe multiverse
+        EOF
+
+        sudo sed -i 's/deb h/deb [arch=amd64] h/g' /etc/apt/sources.list
+
+        sudo dpkg --add-architecture armhf
+        sudo dpkg --add-architecture arm64
+
+        sudo apt-get update && sudo apt-get install -y qemu-user qemu-user-static libstdc++6:armhf libstdc++6:arm64
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: test-builds
+        path: .libsodium-builds/
+
+    - name: Run ${{ matrix.arch }}
+      run: | 
+        chmod +x .libsodium-builds/linux-${{ matrix.arch }}/Tests
+        .libsodium-builds/linux-${{ matrix.arch }}/Tests
+  


### PR DESCRIPTION
Figured out this morning how we can fairly easily multi-arch-test the nuget package process:

- Split Building and Running the tests into two jobs.
- In the first job publish self-contained test binaries in the standard dotnet SDK container.
- In the second job, define a matrix for our various platforms and use QEMU to run them directly.

Using the self-contained publish means that we can directly execute the generated Tests binary (built for the appropriate processor architecture), without needing to install the .NET Runtime or SDK.

Also fixed the wildcard problem with uploading the nuget package by switching to the new version of the upload-artifact action.