### PR TITLE
core.c: Make _sodium_crit_init static

### DIFF
--- a/src/libsodium/sodium/core.c
+++ b/src/libsodium/sodium/core.c
@@ -57,7 +57,7 @@ sodium_init(void)
 static CRITICAL_SECTION _sodium_lock;
 static volatile LONG    _sodium_lock_initialized;
 
-int
+static int
 _sodium_crit_init(void)
 {
     LONG status = 0L;


### PR DESCRIPTION
Found by compiling under MinGW with -Wmissing-declarations.

Is Windows XP still relevant to libsodium? If no, I'll be happy to replace that CRITICAL_SECTION with an SRWLOCK <https://docs.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks>, which will allow deleting both this function and DllMain.