### PR TITLE
sse2_64_32.h: Fix compile errors under 32bit GCC

### DIFF
--- a/src/libsodium/include/sodium/private/sse2_64_32.h
+++ b/src/libsodium/include/sodium/private/sse2_64_32.h
@@ -14,6 +14,11 @@
 # include <emmintrin.h>
 # include <stdint.h>
 
+# ifdef __GNUC__
+#  pragma GCC push_options
+#  pragma GCC target("sse2")
+# endif
+
 # ifndef _mm_set_epi64x
 #  define _mm_set_epi64x(Q0, Q1) sodium__mm_set_epi64x((Q0), (Q1))
 static inline __m128i
@@ -43,6 +48,10 @@ sodium__mm_cvtsi64_si128(int64_t q)
     x.as64 = q;
     return _mm_setr_epi32(x.as32[0], x.as32[1], 0, 0);
 }
+# endif
+
+# ifdef __GNUC__
+#  pragma GCC pop_options
 # endif
 
 #endif


### PR DESCRIPTION
```
In file included from .../src/libsodium/crypto_stream/chacha20/dolbeau/chacha20_dolbeau-ssse3.c:9:
.../src/libsodium/include/sodium/private/sse2_64_32.h: In function 'sodium__mm_set_epi64x':
.../src/libsodium/include/sodium/private/sse2_64_32.h:21:1: warning: SSE vector return without SSE enabled changes the ABI [-Wpsabi]
 {
 ^
In file included from .../src/libsodium/include/sodium/private/sse2_64_32.h:14,
                 from .../src/libsodium/crypto_stream/chacha20/dolbeau/chacha20_dolbeau-ssse3.c:9:
.../i686-w64-mingw32/8.1.0/include/emmintrin.h:601:1: error: inlining failed in call to always_inline '_mm_set_epi32': target specific option mismatch
 _mm_set_epi32 (int __q3, int __q2, int __q1, int __q0)
 ^~~~~~~~~~~~~
In file included from .../src/libsodium/crypto_stream/chacha20/dolbeau/chacha20_dolbeau-ssse3.c:9:
.../src/libsodium/include/sodium/private/sse2_64_32.h:24:12: note: called from here
     return _mm_set_epi32(x1.as32[1], x1.as32[0], x0.as32[1], x0.as32[0]);
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

#pragma GCC push_options was added in GCC 4.4, same as #pragma GCC target ([source](https://gcc.gnu.org/onlinedocs/gcc-4.7.1/gcc/Function-Specific-Option-Pragmas.html)), so this doesn't raise compiler requirements.