### PR TITLE
Use assignment instead of memcpy to copy the value of a pointer

### DIFF
--- a/src/libsodium/crypto_pwhash/argon2/argon2-core.c
+++ b/src/libsodium/crypto_pwhash/argon2/argon2-core.c
@@ -99,12 +99,12 @@ allocate_memory(block_region **region, uint32_t m_cost)
                      -1, 0)) == MAP_FAILED) {
         base = NULL; /* LCOV_EXCL_LINE */
     }                /* LCOV_EXCL_LINE */
-    memcpy(&memory, &base, sizeof memory);
+    memory = base;
 #elif defined(HAVE_POSIX_MEMALIGN)
     if ((errno = posix_memalign((void **) &base, 64, memory_size)) != 0) {
         base = NULL;
     }
-    memcpy(&memory, &base, sizeof memory);
+    memory = base;
 #else
     memory = NULL;
     if (memory_size + 63 < memory_size) {
@@ -113,7 +113,7 @@ allocate_memory(block_region **region, uint32_t m_cost)
     } else if ((base = malloc(memory_size + 63)) != NULL) {
         uint8_t *aligned = ((uint8_t *) base) + 63;
         aligned -= (uintptr_t) aligned & 63;
-        memcpy(&memory, &aligned, sizeof memory);
+        memory = base;
     }
 #endif
     if (base == NULL) {


### PR DESCRIPTION
Some static code analyzers report warnings when `sizeof` is used on a pointer type, as this can be the sign of a missing dereference operation. For example clang's static analyzer has an alpha checker to report such issues, `alpha.core.SizeofPtr`.

In function `allocate_memory`, `sizeof` is used on a pointer:

    void * base;
    block *memory;

    /* ... */

    memcpy(&memory, &base, sizeof memory);

This triggers a warning, and this call to `memcpy` can safely be replaced by a usual assignment (the variables are not special in a way, they are aligned using the default alignment, etc.):

    memory = base;