### PR TITLE
Fix build on z/OS using XLC

### DIFF
--- a/src/libsodium/crypto_generichash/blake2b/ref/blake2.h
+++ b/src/libsodium/crypto_generichash/blake2b/ref/blake2.h
@@ -61,7 +61,7 @@ typedef struct blake2b_state {
     uint8_t  last_node;
 } blake2b_state;
 
-#if defined(__IBMC__) || defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+#if defined(__SUNPRO_C) || defined(__SUNPRO_CC)
 #pragma pack()
 #else
 #pragma pack(pop)

--- a/src/libsodium/include/sodium/crypto_generichash_blake2b.h
+++ b/src/libsodium/include/sodium/crypto_generichash_blake2b.h
@@ -24,7 +24,7 @@ typedef struct CRYPTO_ALIGN(64) crypto_generichash_blake2b_state {
     unsigned char opaque[384];
 } crypto_generichash_blake2b_state;
 
-#if defined(__IBMC__) || defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+#if defined(__SUNPRO_C) || defined(__SUNPRO_CC)
 # pragma pack()
 #else
 # pragma pack(pop)


### PR DESCRIPTION
When compiling with IBMs XL C compiler, structure packing was done incorrectly in the BLAKE2 implementation. Packed structs must be enclosed by `#pragma pack(1)` and `#pragma pack(pop)` to push and pop the packing settings to/from the compiler's stack.

On AIX, `#pragma pack()` is equivalent to `#pragma pack(pop)` according to the docs:
https://www.ibm.com/docs/en/xl-c-aix/13.1.2?topic=descriptions-pragma-pack

On z/OS, however, `#pragma pack()` is equivalent to `#pragma pack(4)` for C code:
https://www.ibm.com/docs/en/zos/2.1.0?topic=descriptions-pragma-pack

So `#pragma pack()` will actually push to the stack instead of pop. As a result, when compiling for 64 bit, my own structs defined in a header were interpreted as packed with 4 byte alignment when used in a module that included my own header and sodium.h. In another module that did not include sodium.h, the struct was correctly interpreted as unpacked (i.e. 8 byte alignment). Passing my struct between both modules did not go well.

This is also why `#pragma pack()` is deprecated.