### PR TITLE
Portability improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -594,7 +594,7 @@ AC_SUBST(CFLAGS_AESNI)
 AC_SUBST(CFLAGS_PCLMUL)
 AC_SUBST(CFLAGS_RDRAND)
 
-AC_CHECK_HEADERS([sys/mman.h sys/random.h intrin.h sys/auxv.h])
+AC_CHECK_HEADERS([sys/mman.h sys/param.h sys/random.h intrin.h sys/auxv.h])
 
 AC_MSG_CHECKING([if _xgetbv() is available])
 AC_LINK_IFELSE(
@@ -822,6 +822,7 @@ AS_IF([test "x$EMSCRIPTEN" = "x"],[
     AC_CHECK_FUNCS([mmap mlock madvise mprotect])
   ])
   AC_CHECK_FUNCS([raise])
+  AC_CHECK_FUNCS([sysconf])
 
   AC_MSG_CHECKING(for getrandom with a standard API)
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[

--- a/configure.ac
+++ b/configure.ac
@@ -820,10 +820,9 @@ AS_IF([test "x$EMSCRIPTEN" = "x"],[
   AC_CHECK_FUNCS([arc4random arc4random_buf])
   AS_IF([test "x$WASI" = "x"],[
     AC_CHECK_FUNCS([mmap mlock madvise mprotect])
+    AC_CHECK_FUNCS([raise])
+    AC_CHECK_FUNCS([sysconf])
   ])
-  AC_CHECK_FUNCS([raise])
-  AC_CHECK_FUNCS([sysconf])
-
   AC_MSG_CHECKING(for getrandom with a standard API)
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <stdlib.h>

--- a/configure.ac
+++ b/configure.ac
@@ -821,6 +821,7 @@ AS_IF([test "x$EMSCRIPTEN" = "x"],[
   AS_IF([test "x$WASI" = "x"],[
     AC_CHECK_FUNCS([mmap mlock madvise mprotect])
   ])
+  AC_CHECK_FUNCS([raise])
 
   AC_MSG_CHECKING(for getrandom with a standard API)
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[

--- a/src/libsodium/sodium/utils.c
+++ b/src/libsodium/sodium/utils.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef HAVE_RAISE
+#if defined(HAVE_RAISE) && !defined(__wasm__)
 # include <signal.h>
 #endif
 
@@ -507,7 +507,7 @@ _mprotect_readwrite(void *ptr, size_t size)
 __attribute__((noreturn)) static void
 _out_of_bounds(void)
 {
-# ifdef HAVE_RAISE
+# if defined(HAVE_RAISE) && !defined(__wasm__)
 #  ifdef SIGSEGV
     raise(SIGSEGV);
 #  elif defined(SIGKILL)

--- a/src/libsodium/sodium/utils.c
+++ b/src/libsodium/sodium/utils.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef __wasm__
+#ifdef HAVE_RAISE
 # include <signal.h>
 #endif
 
@@ -503,7 +503,7 @@ _mprotect_readwrite(void *ptr, size_t size)
 __attribute__((noreturn)) static void
 _out_of_bounds(void)
 {
-# ifndef __wasm__
+# ifdef HAVE_RAISE
 #  ifdef SIGSEGV
     raise(SIGSEGV);
 #  elif defined(SIGKILL)

--- a/src/libsodium/sodium/utils.c
+++ b/src/libsodium/sodium/utils.c
@@ -17,6 +17,10 @@
 # include <sys/mman.h>
 #endif
 
+#ifdef HAVE_SYS_PARAM_H
+# include <sys/param.h>
+#endif
+
 #ifdef _WIN32
 # include <windows.h>
 # include <wincrypt.h>
@@ -402,7 +406,7 @@ int
 _sodium_alloc_init(void)
 {
 #ifdef HAVE_ALIGNED_MALLOC
-# if defined(_SC_PAGESIZE)
+# if defined(_SC_PAGESIZE) && defined(HAVE_SYSCONF)
     long page_size_ = sysconf(_SC_PAGESIZE);
     if (page_size_ > 0L) {
         page_size = (size_t) page_size_;
@@ -411,7 +415,7 @@ _sodium_alloc_init(void)
     SYSTEM_INFO si;
     GetSystemInfo(&si);
     page_size = (size_t) si.dwPageSize;
-# else
+# elif !defined(PAGE_SIZE)
 #  warning Unknown page size
 # endif
     if (page_size < CANARY_SIZE || page_size < sizeof(size_t)) {


### PR DESCRIPTION
Improve portability to aid in porting libsodium to modern game consoles:
- Don't assume that all non-wasm targets have `raise`, `SIGKILL`, etc
- Don't assume that all platforms that have `_SC_PAGESIZE` also have `sysconf` (I've filed a bug with the vendor about the lack of a `sysconf`, but it might not be forthcoming)
- Don't generate warnings if we don't have a way to dynamically determine page size of `PAGE_SIZE` is defined