### PR TITLE
Sign change conditional fix

### DIFF
--- a/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
+++ b/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
@@ -2734,14 +2734,12 @@ ge25519_from_hash(unsigned char s[32], const unsigned char h[64])
     fe25519       fe_f;
     fe25519       x, y, negy;
     int           notsquare;
-    unsigned char y_sign;
 
     fe25519_reduce64(fe_f, h);
     ge25519_elligator2(x, y, fe_f, &notsquare);
 
-    y_sign = notsquare;
     fe25519_neg(negy, y);
-    fe25519_cmov(y, negy, fe25519_isnegative(y) ^ y_sign);
+    fe25519_cmov(y, negy, notsquare == fe25519_isnegative(y));
 
     ge25519_mont_to_ed(p3.X, p3.Y, x, y);
 


### PR DESCRIPTION
Removed the `y_sign` variable as it was misleading to call `y_sign` to `notsquare`. If preferred, we could declare `y_sign = notsquare == fe25519_isnegative(y)` directly. 

The equality check instead of the XOR gate is due to the `hash-to-curve` standard. The [standard](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#section-6.7.1) defines the following two steps: 
```
6.  If is_square(gx1), set x = x1, y = sqrt(gx1), and sgn0(y) = 1.
7.  Else set x = x2, y = sqrt(gx2), and sgn0(y) = 0.
```
meaning that we should end up either with `gx1` a square and `sgn0(y) = 1`, or with `gx1` a nonsquare and `sgn0(y) = 0`. However, the current version of the code computes the XOR gate with the `nonsquare` variable to decide whether we change the sign of `y` or not, meaning that we end up with either `gx1` a nonsquare and `sgn0(y) = 1`, or with `gx1` a square and `sgn0(y) = 0`.

Surprisingly, all tests still pass, with the exception of the `oversized context`. How where these test vectors generated?