### PR TITLE
Calculate carry on most significant byte in crypto_core_ed25519_scalar_add

### DIFF
--- a/src/libsodium/crypto_core/ed25519/core_ed25519.c
+++ b/src/libsodium/crypto_core/ed25519/core_ed25519.c
@@ -206,7 +206,7 @@ crypto_core_ed25519_scalar_add(unsigned char *z, const unsigned char *x,
     memset(y_, 0, sizeof y_);
     memcpy(x_, x, crypto_core_ed25519_SCALARBYTES);
     memcpy(y_, y, crypto_core_ed25519_SCALARBYTES);
-    sodium_add(x_, y_, crypto_core_ed25519_SCALARBYTES);
+    sodium_add(x_, y_, crypto_core_ed25519_NONREDUCEDSCALARBYTES);
     crypto_core_ed25519_scalar_reduce(z, x_);
 }
 


### PR DESCRIPTION
Not sure if the original behavior was intended, but it seems like a bug. If the sum of two scalars is large enough to overflow into a 33-byte serialization, the output was not correct according to `sc_muladd` in https://github.com/orlp/ed25519

Changing the `len` parameter passed into `sodium_add` to `crypto_core_ed25519_NONREDUCEDSCALARBYTES` produces the same results as `sc_muladd`.`