### PR TITLE
update android build scripts to support latest ndk version and prebuilt toolchains

### DIFF
--- a/dist-build/Makefile.am
+++ b/dist-build/Makefile.am
@@ -1,11 +1,8 @@
 
 EXTRA_DIST = \
 	android-build.sh \
-	android-arm.sh \
 	android-armv7-a.sh \
 	android-armv8-a.sh \
-	android-mips32.sh \
-	android-mips64.sh \
 	android-x86.sh \
 	android-x86_64.sh \
 	emscripten.sh \

--- a/dist-build/android-arm.sh
+++ b/dist-build/android-arm.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-export TARGET_ARCH=armv6
-export CFLAGS="-Os -mthumb -marm -march=${TARGET_ARCH}"
-ARCH=arm HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"

--- a/dist-build/android-armv7-a.sh
+++ b/dist-build/android-armv7-a.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 export TARGET_ARCH=armv7-a
 export CFLAGS="-Os -mfloat-abi=softfp -mfpu=vfpv3-d16 -mthumb -marm -march=${TARGET_ARCH}"
-ARCH=arm HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"
+ARCH=arm HOST_COMPILER=armv7a-linux-androideabi "$(dirname "$0")/android-build.sh"

--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -23,8 +23,6 @@ if [ "x$TARGET_ARCH" = 'x' ] || [ "x$ARCH" = 'x' ] || [ "x$HOST_COMPILER" = 'x' 
   exit 1
 fi
 
-export MAKE_TOOLCHAIN="${ANDROID_NDK_HOME}/build/tools/make_standalone_toolchain.py"
-
 export PREFIX="$(pwd)/libsodium-android-${TARGET_ARCH}"
 export TOOLCHAIN_OS_DIR="`uname | tr '[:upper:]' '[:lower:]'`-x86_64/"
 export TOOLCHAIN_DIR="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/${TOOLCHAIN_OS_DIR}"

--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -26,12 +26,13 @@ fi
 export MAKE_TOOLCHAIN="${ANDROID_NDK_HOME}/build/tools/make_standalone_toolchain.py"
 
 export PREFIX="$(pwd)/libsodium-android-${TARGET_ARCH}"
-export TOOLCHAIN_DIR="$(pwd)/android-toolchain-${TARGET_ARCH}"
+export TOOLCHAIN_OS_DIR="`uname | tr '[:upper:]' '[:lower:]'`-x86_64/"
+export TOOLCHAIN_DIR="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/${TOOLCHAIN_OS_DIR}"
+echo "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/${TOOLCHAIN_OS_DIR}/${HOST_COMPILER}"
+
 export PATH="${PATH}:${TOOLCHAIN_DIR}/bin"
-
-export CC=${CC:-"${HOST_COMPILER}-clang"}
-
-rm -rf "${TOOLCHAIN_DIR}" "${PREFIX}"
+SDK_VERSION_NUM=`echo $NDK_PLATFORM | cut -d'-' -f2`
+export CC=${CC:-"${HOST_COMPILER}${SDK_VERSION_NUM}-clang"}
 
 echo
 echo "Warnings related to headers being present but not usable are due to functions"
@@ -47,9 +48,6 @@ else
 fi
 echo
 
-env - PATH="$PATH" \
-  "$MAKE_TOOLCHAIN" --force --api="$NDK_API_VERSION_COMPAT" \
-  --arch="$ARCH" --install-dir="$TOOLCHAIN_DIR" || exit 1
 
 if [ -z "$LIBSODIUM_FULL_BUILD" ]; then
   export LIBSODIUM_ENABLE_MINIMAL_FLAG="--enable-minimal"
@@ -69,9 +67,6 @@ if [ "$NDK_PLATFORM" != "$NDK_PLATFORM_COMPAT" ]; then
   echo
   echo "Configuring again for platform [${NDK_PLATFORM}]"
   echo
-  env - PATH="$PATH" \
-    "$MAKE_TOOLCHAIN" --force --api="$NDK_API_VERSION" \
-    --arch="$ARCH" --install-dir="$TOOLCHAIN_DIR" || exit 1
 
   ./configure \
     --disable-soname-versions \

--- a/dist-build/android-mips32.sh
+++ b/dist-build/android-mips32.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-export TARGET_ARCH=mips32
-export CFLAGS="-Os"
-ARCH=mips HOST_COMPILER=mipsel-linux-android "$(dirname "$0")/android-build.sh"

--- a/dist-build/android-mips64.sh
+++ b/dist-build/android-mips64.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-export TARGET_ARCH=mips64r6
-export CFLAGS="-Os -march=${TARGET_ARCH}"
-CC="mips64el-linux-android-gcc" NDK_PLATFORM=android-21 ARCH=mips64 HOST_COMPILER=mips64el-linux-android "$(dirname "$0")/android-build.sh"


### PR DESCRIPTION
I'm not sure if it's desired to maybe create a second set of scripts instead. The existing android build scripts don't work with the latest ndk. The latest ndk dropped support for arm prior to armv7a and mips. It is now recommended that prebuilt toolchains be used instead of creating a toolchain for each build (this also saves a lot of disk space.) I've tested this new script and it works on the latest development version of Ubuntu and the latest version of MacOS. perhaps a different folder with android-legacy or something like that for the old architectures? 