### PR TITLE
Added script to generate all android versions and script to create AAR

### DIFF
--- a/dist-build/Makefile.am
+++ b/dist-build/Makefile.am
@@ -2,7 +2,6 @@
 EXTRA_DIST = \
 	android-build.sh \
 	android-aar.sh \
-	android-all.sh \
 	android-armv7-a.sh \
 	android-armv8-a.sh \
 	android-x86.sh \

--- a/dist-build/Makefile.am
+++ b/dist-build/Makefile.am
@@ -1,6 +1,8 @@
 
 EXTRA_DIST = \
 	android-build.sh \
+	android-aar.sh \
+	android-all.sh \
 	android-armv7-a.sh \
 	android-armv8-a.sh \
 	android-x86.sh \

--- a/dist-build/android-aar.sh
+++ b/dist-build/android-aar.sh
@@ -106,3 +106,31 @@ rm "$AAR_PATH"
 zip -r "$AAR_PATH" META-INF prefab AndroidManifest.xml
 cd .. || exit
 rm -r "$DEST_PATH"
+clear
+echo "congrats you have built an AAR containing libsodium. To use it with 
+gradle / cmake (defaults for Android Studio projects) simply:
+
+edit the app/build.gradle file to add:
+
+    android {
+        buildFeatures {
+            prefab true
+        }
+    }
+    
+    #and
+    dependencies {
+        implementation fileTree(dir:'path/to/aar/',include:['libsodium-$SODIUM_VERSION.aar']) 
+    }
+    #you can optionally store multiple AAR files in the same folder and include '*.aar'
+
+edit your module's CMakeLists.txt file to add:
+    
+    find_package(sodium REQUIRED CONFIG)
+    
+    # the specify sodium::sodium as an item in the relevant target_link_libraries statement
+    # the first value specifies the AAR and is always sodium the second is the library 
+    # name which supports sodium for the full shared library sodium-static
+    # for the full static library sodium-minimal for the minimal shared library
+    # or sodium-minimal-static for the minimal static library"
+

--- a/dist-build/android-aar.sh
+++ b/dist-build/android-aar.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+
+#creates an AAR with libsodium in 4 configurations all combinations of static | shared | minimal | full
+#the x86 static library will not work due to text relocation rules and so all static x86 versions are just the shared library
+#to simplify linking each version of the library is given a different name sodium, sodium-static, sodium-minimal and sodium-minimal-static
+
+SODIUM_VERSION="1.0.18.0"
+NDK_VERSION=$(grep "Pkg.Revision = " <"$ANDROID_NDK_HOME/source.properties" | cut -f 2 -d '=' | cut -f 2 -d' ' | cut -f 1 -d'.')
+DEST_PATH=$(mktemp -d)
+
+cd "$(dirname "$0")/../" || exit
+
+make_abi_json() {
+  if [ -z "$2" ]; then
+    STL_VALUE="c++_shared"
+  else
+    STL_VALUE="c++_static"
+  fi
+  echo "{\"abi\":\"$NDK_ARCH\",\"api\":$SDK_VERSION,\"ndk\":$NDK_VERSION,\"stl\":\"$STL_VALUE\"}" >"$1/abi.json"
+}
+
+make_prefab_json() {
+  echo "{\"name\":\"sodium\",\"schema_version\":1,\"dependencies\":[],\"version\":\"$SODIUM_VERSION\"}" >"$1/prefab.json"
+}
+
+make_manifest() {
+  echo "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" package=\"com.android.ndk.thirdparty.sodium\" android:versionCode=\"1\" android:versionName=\"1.0\">
+	<uses-sdk android:minSdkVersion=\"19\" android:targetSdkVersion=\"21\"/>
+</manifest>" >"$1/AndroidManifest.xml"
+
+}
+
+make_prefab_structure() {
+  mkdir "$DEST_PATH"
+  for i in "prefab" "prefab/modules" "META-INF"; do
+    mkdir "$DEST_PATH/$i"
+  done
+  make_prefab_json "$DEST_PATH/prefab"
+  make_manifest "$DEST_PATH"
+  cp "LICENSE" "$DEST_PATH/META-INF"
+  for i in "prefab/modules/sodium" "prefab/modules/sodium-static" "prefab/modules/sodium-minimal" "prefab/modules/sodium-minimal-static"; do
+    mkdir "$DEST_PATH/$i"
+    mkdir "$DEST_PATH/$i/libs"
+    for j in "arm64-v8a" "armeabi-v7a" "x86" "x86_64"; do
+      mkdir "$DEST_PATH/$i/libs/android.$j"
+      mkdir "$DEST_PATH/$i/libs/android.$j/include"
+      NDK_ARCH="$j"
+      if [ $j = "arm64-v8a" ] || [ $j = "x86_64" ]; then
+        SDK_VERSION="21"
+      else
+        SDK_VERSION="19"
+
+      fi
+
+      if [ $j != "x86" ]; then
+        if [ $i = "prefab/modules/sodium-minimal-static" ] || [ $i = "prefab/modules/sodium-static" ]; then
+          make_abi_json "$DEST_PATH/$i/libs/android.$j" static
+        else
+          make_abi_json "$DEST_PATH/$i/libs/android.$j"
+        fi
+      else
+        make_abi_json "$DEST_PATH/$i/libs/android.$j"
+      fi
+    done
+  done
+}
+
+copy_libs() {
+  SRC_DIR="libsodium-android-$1"
+
+  SHARED_DEST_DIR="$DEST_PATH/prefab/modules/sodium$3/libs/android.$2"
+  STATIC_DEST_DIR="$DEST_PATH/prefab/modules/sodium$3-static/libs/android.$2"
+
+  cp -r "$SRC_DIR/include" "$SHARED_DEST_DIR"
+  cp -r "$SRC_DIR/include" "$STATIC_DEST_DIR"
+  cp "$SRC_DIR/lib/libsodium.so" "$SHARED_DEST_DIR/libsodium$3.so"
+  if [ "$2" = "x86" ]; then
+    cp "$SRC_DIR/lib/libsodium.so" "$STATIC_DEST_DIR/libsodium$3-static.so"
+  else
+    cp "$SRC_DIR/lib/libsodium.a" "$STATIC_DEST_DIR/libsodium$3-static.a"
+  fi
+  rm -r "$SRC_DIR"
+}
+
+make_prefab_structure
+
+"dist-build/android-all.sh"
+
+copy_libs "armv7-a" "armeabi-v7a" "-minimal"
+copy_libs "armv8-a+crypto" "arm64-v8a" "-minimal"
+copy_libs "i686" "x86" "-minimal"
+copy_libs "westmere" "x86_64" "-minimal"
+
+LIBSODIUM_FULL_BUILD="Y"
+export LIBSODIUM_FULL_BUILD
+
+"dist-build/android-all.sh"
+
+copy_libs "armv7-a" "armeabi-v7a"
+copy_libs "armv8-a+crypto" "arm64-v8a"
+copy_libs "i686" "x86"
+copy_libs "westmere" "x86_64"
+
+AAR_PATH="$(pwd)/libsodium-$SODIUM_VERSION.aar"
+cd "$DEST_PATH" || exit
+rm "$AAR_PATH"
+zip -r "$AAR_PATH" META-INF prefab AndroidManifest.xml
+cd .. || exit
+rm -r "$DEST_PATH"

--- a/dist-build/android-all.sh
+++ b/dist-build/android-all.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-"$(dirname "$0")/android-armv7-a.sh"
-"$(dirname "$0")/android-armv8-a.sh"
-"$(dirname "$0")/android-x86_64.sh"
-"$(dirname "$0")/android-x86.sh"

--- a/dist-build/android-all.sh
+++ b/dist-build/android-all.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+"$(dirname "$0")/android-armv7-a.sh"
+"$(dirname "$0")/android-armv8-a.sh"
+"$(dirname "$0")/android-x86_64.sh"
+"$(dirname "$0")/android-x86.sh"

--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -55,6 +55,7 @@ fi
 
 ./configure \
   --disable-soname-versions \
+  --disable-pie \
   ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
   --host="${HOST_COMPILER}" \
   --prefix="${PREFIX}" \
@@ -68,6 +69,7 @@ if [ "$NDK_PLATFORM" != "$NDK_PLATFORM_COMPAT" ]; then
 
   ./configure \
     --disable-soname-versions \
+    --disable-pie \
     ${LIBSODIUM_ENABLE_MINIMAL_FLAG} \
     --host="${HOST_COMPILER}" \
     --prefix="${PREFIX}" \


### PR DESCRIPTION
1. Added a very simple android-all.sh script that simply runs through all the android build scripts and runs them all. 
2. Added android-aar.sh script which builds an [AAR with a prefab](https://google.github.io/prefab/) suitable for uploading to Maven (if you run the script on a stable codebase).
  - Existing users still have all the old build scripts;
  - New users can generate an AAR very easily that contains all useful combinations of build scenarios in a package that integrates with the major tools used for android development. See [https://developer.android.com/studio/projects/android-library](https://developer.android.com/studio/projects/android-library)  
  - builds static and dynamic versions of the library in both full and minimal mode and names them sodium sodium-static sodium-minimal and sodium-minimal-static within the AAR so it's easy to control static vs dynamic linkage for compilers or build systems that don't support specifying.
  - the x86 static library is a lie... it uses the dynamic library as the static library contains text relocations that won't allow it to link with android applications.

One item I wasn't totally sure of was the best way to set the libsodium version in the generated metadata as it seems to be hard coded in multiple places through the codebase? I leave that as a future cleanup item.

Edit: [another useful link on AARs and prefabs](https://android-developers.googleblog.com/2020/02/native-dependencies-in-android-studio-40.html) 