### PR TITLE
Use .NET 6 SDK to build and test the NuGet package

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -206,7 +206,7 @@ jobs:
       - build-macos-x64
       - build-macos-arm64
     container:
-      image: mcr.microsoft.com/dotnet/sdk:5.0
+      image: mcr.microsoft.com/dotnet/sdk:6.0
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -259,7 +259,7 @@ jobs:
     needs:
       - pack
     container:
-      image: mcr.microsoft.com/dotnet/sdk:5.0
+      image: mcr.microsoft.com/dotnet/sdk:6.0
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -288,9 +288,9 @@ jobs:
       - name: Move Build Output
         run: |
           mkdir .libsodium-builds
-          mv .libsodium-test/bin/Release/net5.0/linux-arm/publish .libsodium-builds/linux-arm
-          mv .libsodium-test/bin/Release/net5.0/linux-arm64/publish .libsodium-builds/linux-arm64
-          mv .libsodium-test/bin/Release/net5.0/linux-x64/publish .libsodium-builds/linux-x64
+          mv .libsodium-test/bin/Release/net6.0/linux-arm/publish .libsodium-builds/linux-arm
+          mv .libsodium-test/bin/Release/net6.0/linux-arm64/publish .libsodium-builds/linux-arm64
+          mv .libsodium-test/bin/Release/net6.0/linux-x64/publish .libsodium-builds/linux-x64
       - uses: actions/upload-artifact@v2
         with:
           name: test-builds


### PR DESCRIPTION
Since .NET 5 [is reaching EOL](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core), this PR updates the building and testing of the NuGet package to .NET 6.
This does not affect with which .NET versions the NuGet package can be used.

Resolves #1122