### PR TITLE
Update wasi-test-wrapper: SSVM was renamed to WasmEdge

### DIFF
--- a/test/default/wasi-test-wrapper.sh
+++ b/test/default/wasi-test-wrapper.sh
@@ -39,11 +39,12 @@ if [ -z "$WASI_RUNTIME" ] || [ "$WASI_RUNTIME" = "iwasm" ]; then
   fi
 fi
 
-if [ -z "$WASI_RUNTIME" ] || [ "$WASI_RUNTIME" = "ssvm" ]; then
-  if command -v ssvmc >/dev/null && command -v ssvm >/dev/null; then
-    ssvmc "$1" "${1}.so" &&
-      ssvm --dir=.:. "${1}.so" &&
-      rm -f "${1}.so"
+if [ -z "$WASI_RUNTIME" ] || [ "$WASI_RUNTIME" = "wasmedge" ]; then
+  if command -v wasmedgec >/dev/null && command -v wasmedge >/dev/null; then
+    wasmedgec "$1" "${1}.so" &&
+      wasmedge --dir=.:. "${1}.so" &&
+      rm -f "${1}.so" &&
+      exit 0
   fi
 fi
 


### PR DESCRIPTION
In short, SSVM was renamed to [WasmEdge](https://github.com/WasmEdge/WasmEdge) at [0.8.1](https://github.com/WasmEdge/WasmEdge/blob/master/Changelog.md#081-2021-06-18).

I'm working on [a Github Action to run libsodium tests on selected runtime](https://github.com/second-state/actions-run-libsodium-tests) (still WIP) so that we can [reproduce the results](https://github.com/jedisct1/webassembly-benchmarks/issues/2) automatically on Github.

Since we're supposed to run libsodium tests on `stable`, I hope this patch could also be picked to `stable`.