### PR TITLE
Add parallelism setting to crypto_pwhash_argon2i() and crypto_pwhash_argon2id()

### DIFF
--- a/src/libsodium/crypto_pwhash/argon2/pwhash_argon2i.c
+++ b/src/libsodium/crypto_pwhash/argon2/pwhash_argon2i.c
@@ -140,7 +140,8 @@ int
 crypto_pwhash_argon2i(unsigned char *const out, unsigned long long outlen,
                       const char *const passwd, unsigned long long passwdlen,
                       const unsigned char *const salt,
-                      unsigned long long opslimit, size_t memlimit, int alg)
+                      unsigned long long opslimit, size_t memlimit,
+                      size_t joblimit, int alg)
 {
     memset(out, 0, outlen);
     if (outlen > crypto_pwhash_argon2i_BYTES_MAX) {
@@ -170,7 +171,7 @@ crypto_pwhash_argon2i(unsigned char *const out, unsigned long long outlen,
     switch (alg) {
     case crypto_pwhash_argon2i_ALG_ARGON2I13:
         if (argon2i_hash_raw((uint32_t) opslimit, (uint32_t) (memlimit / 1024U),
-                             (uint32_t) 1U, passwd, (size_t) passwdlen, salt,
+                             (uint32_t) joblimit, passwd, (size_t) passwdlen, salt,
                              (size_t) crypto_pwhash_argon2i_SALTBYTES, out,
                              (size_t) outlen) != ARGON2_OK) {
             return -1; /* LCOV_EXCL_LINE */
@@ -186,7 +187,8 @@ int
 crypto_pwhash_argon2i_str(char out[crypto_pwhash_argon2i_STRBYTES],
                           const char *const passwd,
                           unsigned long long passwdlen,
-                          unsigned long long opslimit, size_t memlimit)
+                          unsigned long long opslimit, size_t memlimit,
+                          size_t joblimit)
 {
     unsigned char salt[crypto_pwhash_argon2i_SALTBYTES];
 
@@ -205,7 +207,7 @@ crypto_pwhash_argon2i_str(char out[crypto_pwhash_argon2i_STRBYTES],
     }
     randombytes_buf(salt, sizeof salt);
     if (argon2i_hash_encoded((uint32_t) opslimit, (uint32_t) (memlimit / 1024U),
-                             (uint32_t) 1U, passwd, (size_t) passwdlen, salt,
+                             (uint32_t) joblimit, passwd, (size_t) passwdlen, salt,
                              sizeof salt, STR_HASHBYTES, out,
                              crypto_pwhash_argon2i_STRBYTES) != ARGON2_OK) {
         return -1; /* LCOV_EXCL_LINE */
@@ -243,7 +245,7 @@ crypto_pwhash_argon2i_str_verify(const char * str,
 
 static int
 _needs_rehash(const char *str, unsigned long long opslimit, size_t memlimit,
-              argon2_type type)
+              size_t, joblimit, argon2_type type)
 {
     unsigned char  *fodder;
     argon2_context  ctx;
@@ -281,14 +283,16 @@ _needs_rehash(const char *str, unsigned long long opslimit, size_t memlimit,
 
 int
 crypto_pwhash_argon2i_str_needs_rehash(const char * str,
-                                       unsigned long long opslimit, size_t memlimit)
+                                       unsigned long long opslimit, size_t memlimit,
+                                       size_t joblimit)
 {
-    return _needs_rehash(str, opslimit, memlimit, Argon2_i);
+    return _needs_rehash(str, opslimit, memlimit, joblimit, Argon2_i);
 }
 
 int
 crypto_pwhash_argon2id_str_needs_rehash(const char * str,
-                                        unsigned long long opslimit, size_t memlimit)
+                                       unsigned long long opslimit, size_t memlimit,
+                                       size_t joblimit)
 {
-    return _needs_rehash(str, opslimit, memlimit, Argon2_id);
+    return _needs_rehash(str, opslimit, memlimit, joblimit, Argon2_id);
 }

--- a/src/libsodium/crypto_pwhash/argon2/pwhash_argon2id.c
+++ b/src/libsodium/crypto_pwhash/argon2/pwhash_argon2id.c
@@ -191,14 +191,13 @@ crypto_pwhash_argon2id_str(char out[crypto_pwhash_argon2id_STRBYTES],
     memset(out, 0, crypto_pwhash_argon2id_STRBYTES);
     if (passwdlen > crypto_pwhash_argon2id_PASSWD_MAX ||
         opslimit > crypto_pwhash_argon2id_OPSLIMIT_MAX ||
-        memlimit > crypto_pwhash_argon2id_MEMLIMIT_MAX) ||
-        joblimit > crypto_pwhash_argon2id_JOBLIMIT_MAX) {
+        memlimit > crypto_pwhash_argon2id_MEMLIMIT_MAX) {
         errno = EFBIG;
         return -1;
     }
     if (passwdlen < crypto_pwhash_argon2id_PASSWD_MIN ||
         opslimit < crypto_pwhash_argon2id_OPSLIMIT_MIN ||
-        joblimit < crypto_pwhash_argon2id_JOBLIMIT_MIN) {
+        memlimit < crypto_pwhash_argon2id_MEMLIMIT_MIN) {
         errno = EINVAL;
         return -1;
     }

--- a/src/libsodium/crypto_pwhash/argon2/pwhash_argon2id.c
+++ b/src/libsodium/crypto_pwhash/argon2/pwhash_argon2id.c
@@ -136,7 +136,8 @@ int
 crypto_pwhash_argon2id(unsigned char *const out, unsigned long long outlen,
                        const char *const passwd, unsigned long long passwdlen,
                        const unsigned char *const salt,
-                       unsigned long long opslimit, size_t memlimit, int alg)
+                       unsigned long long opslimit, size_t memlimit,
+                       size_t joblimit, int alg)
 {
     memset(out, 0, outlen);
     if (outlen > crypto_pwhash_argon2id_BYTES_MAX) {
@@ -166,7 +167,7 @@ crypto_pwhash_argon2id(unsigned char *const out, unsigned long long outlen,
     switch (alg) {
     case crypto_pwhash_argon2id_ALG_ARGON2ID13:
         if (argon2id_hash_raw((uint32_t) opslimit, (uint32_t) (memlimit / 1024U),
-                              (uint32_t) 1U, passwd, (size_t) passwdlen, salt,
+                              (uint32_t) joblimit, passwd, (size_t) passwdlen, salt,
                               (size_t) crypto_pwhash_argon2id_SALTBYTES, out,
                               (size_t) outlen) != ARGON2_OK) {
             return -1; /* LCOV_EXCL_LINE */
@@ -182,26 +183,28 @@ int
 crypto_pwhash_argon2id_str(char out[crypto_pwhash_argon2id_STRBYTES],
                            const char *const passwd,
                            unsigned long long passwdlen,
-                           unsigned long long opslimit, size_t memlimit)
+                           unsigned long long opslimit, size_t memlimit,
+                           size_t joblimit)
 {
     unsigned char salt[crypto_pwhash_argon2id_SALTBYTES];
 
     memset(out, 0, crypto_pwhash_argon2id_STRBYTES);
     if (passwdlen > crypto_pwhash_argon2id_PASSWD_MAX ||
         opslimit > crypto_pwhash_argon2id_OPSLIMIT_MAX ||
-        memlimit > crypto_pwhash_argon2id_MEMLIMIT_MAX) {
+        memlimit > crypto_pwhash_argon2id_MEMLIMIT_MAX) ||
+        joblimit > crypto_pwhash_argon2id_JOBLIMIT_MAX) {
         errno = EFBIG;
         return -1;
     }
     if (passwdlen < crypto_pwhash_argon2id_PASSWD_MIN ||
         opslimit < crypto_pwhash_argon2id_OPSLIMIT_MIN ||
-        memlimit < crypto_pwhash_argon2id_MEMLIMIT_MIN) {
+        joblimit < crypto_pwhash_argon2id_JOBLIMIT_MIN) {
         errno = EINVAL;
         return -1;
     }
     randombytes_buf(salt, sizeof salt);
     if (argon2id_hash_encoded((uint32_t) opslimit, (uint32_t) (memlimit / 1024U),
-                              (uint32_t) 1U, passwd, (size_t) passwdlen, salt,
+                              (uint32_t) joblimit, passwd, (size_t) passwdlen, salt,
                               sizeof salt, STR_HASHBYTES, out,
                               crypto_pwhash_argon2id_STRBYTES) != ARGON2_OK) {
         return -1; /* LCOV_EXCL_LINE */

--- a/src/libsodium/crypto_pwhash/crypto_pwhash.c
+++ b/src/libsodium/crypto_pwhash/crypto_pwhash.c
@@ -134,10 +134,10 @@ crypto_pwhash(unsigned char * const out, unsigned long long outlen,
     switch (alg) {
     case crypto_pwhash_ALG_ARGON2I13:
         return crypto_pwhash_argon2i(out, outlen, passwd, passwdlen, salt,
-                                     opslimit, memlimit, alg);
+                                     opslimit, memlimit, 1U, alg);
     case crypto_pwhash_ALG_ARGON2ID13:
         return crypto_pwhash_argon2id(out, outlen, passwd, passwdlen, salt,
-                                      opslimit, memlimit, alg);
+                                      opslimit, memlimit, 1U, alg);
     default:
         errno = EINVAL;
         return -1;
@@ -147,7 +147,7 @@ crypto_pwhash(unsigned char * const out, unsigned long long outlen,
 int
 crypto_pwhash_str(char out[crypto_pwhash_STRBYTES],
                   const char * const passwd, unsigned long long passwdlen,
-                  unsigned long long opslimit, size_t memlimit)
+                  unsigned long long opslimit, size_t memlimit, 1U)
 {
     return crypto_pwhash_argon2id_str(out, passwd, passwdlen,
                                       opslimit, memlimit);
@@ -161,10 +161,10 @@ crypto_pwhash_str_alg(char out[crypto_pwhash_STRBYTES],
     switch (alg) {
     case crypto_pwhash_ALG_ARGON2I13:
         return crypto_pwhash_argon2i_str(out, passwd, passwdlen,
-                                         opslimit, memlimit);
+                                         opslimit, memlimit, 1U);
     case crypto_pwhash_ALG_ARGON2ID13:
         return crypto_pwhash_argon2id_str(out, passwd, passwdlen,
-                                          opslimit, memlimit);
+                                          opslimit, memlimit, 1U);
     }
     sodium_misuse();
     /* NOTREACHED */
@@ -195,11 +195,11 @@ crypto_pwhash_str_needs_rehash(const char * str,
 {
     if (strncmp(str, crypto_pwhash_argon2id_STRPREFIX,
                 sizeof crypto_pwhash_argon2id_STRPREFIX - 1) == 0) {
-        return crypto_pwhash_argon2id_str_needs_rehash(str, opslimit, memlimit);
+        return crypto_pwhash_argon2id_str_needs_rehash(str, opslimit, memlimit, 1U);
     }
     if (strncmp(str, crypto_pwhash_argon2i_STRPREFIX,
                 sizeof crypto_pwhash_argon2i_STRPREFIX - 1) == 0) {
-        return crypto_pwhash_argon2i_str_needs_rehash(str, opslimit, memlimit);
+        return crypto_pwhash_argon2i_str_needs_rehash(str, opslimit, memlimit, 1U);
     }
     errno = EINVAL;
 

--- a/src/libsodium/include/sodium/crypto_pwhash_argon2i.h
+++ b/src/libsodium/include/sodium/crypto_pwhash_argon2i.h
@@ -94,14 +94,15 @@ int crypto_pwhash_argon2i(unsigned char * const out,
                           unsigned long long passwdlen,
                           const unsigned char * const salt,
                           unsigned long long opslimit, size_t memlimit,
-                          int alg)
+                          size_t joblimit, int alg)
             __attribute__ ((warn_unused_result)) __attribute__ ((nonnull));
 
 SODIUM_EXPORT
 int crypto_pwhash_argon2i_str(char out[crypto_pwhash_argon2i_STRBYTES],
                               const char * const passwd,
                               unsigned long long passwdlen,
-                              unsigned long long opslimit, size_t memlimit)
+                              unsigned long long opslimit, size_t memlimit,
+                              size_t joblimit)
             __attribute__ ((warn_unused_result)) __attribute__ ((nonnull));
 
 SODIUM_EXPORT
@@ -112,7 +113,8 @@ int crypto_pwhash_argon2i_str_verify(const char * str,
 
 SODIUM_EXPORT
 int crypto_pwhash_argon2i_str_needs_rehash(const char * str,
-                                           unsigned long long opslimit, size_t memlimit)
+                                           unsigned long long opslimit, size_t memlimit,
+                                           size_t joblimit)
             __attribute__ ((warn_unused_result))  __attribute__ ((nonnull));
 
 #ifdef __cplusplus

--- a/src/libsodium/include/sodium/crypto_pwhash_argon2id.h
+++ b/src/libsodium/include/sodium/crypto_pwhash_argon2id.h
@@ -94,14 +94,15 @@ int crypto_pwhash_argon2id(unsigned char * const out,
                            unsigned long long passwdlen,
                            const unsigned char * const salt,
                            unsigned long long opslimit, size_t memlimit,
-                           int alg)
+                           size_t joblimit, int alg)
             __attribute__ ((warn_unused_result)) __attribute__ ((nonnull));
 
 SODIUM_EXPORT
 int crypto_pwhash_argon2id_str(char out[crypto_pwhash_argon2id_STRBYTES],
                                const char * const passwd,
                                unsigned long long passwdlen,
-                               unsigned long long opslimit, size_t memlimit)
+                               unsigned long long opslimit, size_t memlimit,
+                               size_t joblimit)
             __attribute__ ((warn_unused_result)) __attribute__ ((nonnull));
 
 SODIUM_EXPORT
@@ -112,7 +113,8 @@ int crypto_pwhash_argon2id_str_verify(const char * str,
 
 SODIUM_EXPORT
 int crypto_pwhash_argon2id_str_needs_rehash(const char * str,
-                                            unsigned long long opslimit, size_t memlimit)
+                                            unsigned long long opslimit, size_t memlimit,
+                                            size_t joblimit)
             __attribute__ ((warn_unused_result))  __attribute__ ((nonnull));
 
 #ifdef __cplusplus


### PR DESCRIPTION
This effectively add a new parameters "joblimit" to the Argon2 specific fonctions exposed by the `crypto_pwhash` API.

Parallelism is one of the 3 parameters that define the Argon2 algorithm, but it cannot be changed using the API. This makes libsodium incompatible with any other implementation, and incompatible with [RFC 9106][rfc9106] recommended settings for Argon2.

In order to keep compatibility with previous version, I didn't change the `crypto_pwhash()` function, which is now where the parallelism value of `1U` is hardcoded.
By using the argon2 specific function, users can can change this parameter, which is already fully implemented and working internally. This MR only expose the parameter to the API.

[rfc9106]: https://www.rfc-editor.org/rfc/rfc9106.html