### PR TITLE
build: do not define the sodium target when not found by CMake

### DIFF
--- a/contrib/Findsodium.cmake
+++ b/contrib/Findsodium.cmake
@@ -231,6 +231,10 @@ find_package_handle_standard_args(sodium
                                   VERSION_VAR
                                   sodium_VERSION_STRING)
 
+if (NOT sodium_FOUND)
+  return()
+endif()
+
 # mark file paths as advanced
 mark_as_advanced(sodium_INCLUDE_DIR)
 mark_as_advanced(sodium_LIBRARY_DEBUG)


### PR DESCRIPTION
As specified in the docs, `sodium_FOUND` is set when all the required vars are found. Previously the code defined an incorrect sodium target even though the needed variables were not found. This prevents subsequent searches by other methods. This PR fixes the issue by an early return.

https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html