### PR TITLE
Build correctly with IBT and Shadow Stack

### DIFF
--- a/src/libsodium/crypto_scalarmult/curve25519/sandy2x/sandy2x.S
+++ b/src/libsodium/crypto_scalarmult/curve25519/sandy2x/sandy2x.S
@@ -9,6 +9,24 @@
 #include "ladder.S"
 
 #if defined(__linux__) && defined(__ELF__)
+#if defined(__CET__)
+.section	.note.gnu.property,"a"
+.p2align 3
+.long	1f - 0f
+.long	4f - 1f
+.long	5
+0:
+.string	"GNU"
+1:
+.p2align 3
+.long	0xc0000002
+.long	3f - 2f
+2:
+.long	__CET__
+3:
+.p2align 3
+4:
+#endif
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/src/libsodium/crypto_stream/salsa20/xmm6/salsa20_xmm6-asm.S
+++ b/src/libsodium/crypto_stream/salsa20/xmm6/salsa20_xmm6-asm.S
@@ -958,5 +958,23 @@ jmp ._bytesbetween1and255
 #endif
 
 #if defined(__linux__) && defined(__ELF__)
+#if defined(__CET__)
+.section	.note.gnu.property,"a"
+.p2align 3
+.long	1f - 0f
+.long	4f - 1f
+.long	5
+0:
+.string	"GNU"
+1:
+.p2align 3
+.long	0xc0000002
+.long	3f - 2f
+2:
+.long	__CET__
+3:
+.p2align 3
+4:
+#endif
 .section .note.GNU-stack,"",%progbits
 #endif


### PR DESCRIPTION
Add .gnu.property notes to indicate support for IBT and shadow stacks when libsodium is built with it.  There's no stack switching code in here, so this should not need any other codegen changes.

Without this, the following build configuration fails:

`./configure CFLAGS="-O2 -fcf-protection" LDFLAGS=-Wl,-z,cet-report=error`