### PR TITLE
Add proper CET support

### DIFF
--- a/src/libsodium/crypto_scalarmult/curve25519/sandy2x/fe51_mul.S
+++ b/src/libsodium/crypto_scalarmult/curve25519/sandy2x/fe51_mul.S
@@ -3,6 +3,7 @@
 /*
    This file is basically amd64-51/fe25519_mul.s.
 */
+#include <private/common.h>
 #include "fe51_namespace.h"
 #include "consts_namespace.h"
 .text
@@ -19,6 +20,7 @@ ASM_HIDE_SYMBOL _fe51_mul
 #endif
 fe51_mul:
 _fe51_mul:
+_CET_ENDBR
 mov %rsp,%r11
 and $31,%r11
 add $96,%r11

--- a/src/libsodium/crypto_scalarmult/curve25519/sandy2x/fe51_nsquare.S
+++ b/src/libsodium/crypto_scalarmult/curve25519/sandy2x/fe51_nsquare.S
@@ -4,6 +4,7 @@
    This file is adapted from amd64-51/fe25519_square.s:
    Adding loop to perform n squares.
 */
+#include <private/common.h>
 #include "fe51_namespace.h"
 #include "consts_namespace.h"
 .p2align 5
@@ -21,6 +22,7 @@ ASM_HIDE_SYMBOL _fe51_nsquare
 fe51_nsquare:
 _fe51_nsquare:
 
+_CET_ENDBR
 mov %rsp,%r11
 and $31,%r11
 add $64,%r11

--- a/src/libsodium/crypto_scalarmult/curve25519/sandy2x/fe51_pack.S
+++ b/src/libsodium/crypto_scalarmult/curve25519/sandy2x/fe51_pack.S
@@ -4,6 +4,7 @@
    This file is the result of merging 
    amd64-51/fe25519_pack.c and amd64-51/fe25519_freeze.s.
 */
+#include <private/common.h>
 #include "fe51_namespace.h"
 #include "consts_namespace.h"
 .p2align 5
@@ -21,6 +22,7 @@ ASM_HIDE_SYMBOL _fe51_pack
 fe51_pack:
 _fe51_pack:
 
+_CET_ENDBR
 mov %rsp,%r11
 and $31,%r11
 add $32,%r11

--- a/src/libsodium/crypto_scalarmult/curve25519/sandy2x/ladder.S
+++ b/src/libsodium/crypto_scalarmult/curve25519/sandy2x/ladder.S
@@ -1,5 +1,6 @@
 #ifdef IN_SANDY2X
 
+#include <private/common.h>
 #include "ladder_namespace.h"
 #include "consts_namespace.h"
 .p2align 5
@@ -17,6 +18,7 @@ ASM_HIDE_SYMBOL _ladder
 ladder:
 _ladder:
 
+_CET_ENDBR
 mov %rsp,%r11
 and $31,%r11
 add $1856,%r11

--- a/src/libsodium/crypto_scalarmult/curve25519/sandy2x/sandy2x.S
+++ b/src/libsodium/crypto_scalarmult/curve25519/sandy2x/sandy2x.S
@@ -9,24 +9,6 @@
 #include "ladder.S"
 
 #if defined(__linux__) && defined(__ELF__)
-#if defined(__CET__)
-.section	.note.gnu.property,"a"
-.p2align 3
-.long	1f - 0f
-.long	4f - 1f
-.long	5
-0:
-.string	"GNU"
-1:
-.p2align 3
-.long	0xc0000002
-.long	3f - 2f
-2:
-.long	__CET__
-3:
-.p2align 3
-4:
-#endif
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/src/libsodium/crypto_stream/salsa20/xmm6/salsa20_xmm6-asm.S
+++ b/src/libsodium/crypto_stream/salsa20/xmm6/salsa20_xmm6-asm.S
@@ -1,5 +1,6 @@
 #ifdef HAVE_AMD64_ASM
 
+#include <private/common.h>
 #include "salsa20_xmm6-asm_namespace.h"
 
 .text
@@ -17,6 +18,7 @@ ASM_HIDE_SYMBOL _stream_salsa20_xmm6
 #endif
 stream_salsa20_xmm6:
 _stream_salsa20_xmm6:
+_CET_ENDBR
 mov %rsp,%r11
 and $31,%r11
 add $512,%r11
@@ -58,6 +60,7 @@ ASM_HIDE_SYMBOL _stream_salsa20_xmm6_xor_ic
 stream_salsa20_xmm6_xor_ic:
 _stream_salsa20_xmm6_xor_ic:
 
+_CET_ENDBR
 mov %rsp,%r11
 and $31,%r11
 add $512,%r11
@@ -958,23 +961,5 @@ jmp ._bytesbetween1and255
 #endif
 
 #if defined(__linux__) && defined(__ELF__)
-#if defined(__CET__)
-.section	.note.gnu.property,"a"
-.p2align 3
-.long	1f - 0f
-.long	4f - 1f
-.long	5
-0:
-.string	"GNU"
-1:
-.p2align 3
-.long	0xc0000002
-.long	3f - 2f
-2:
-.long	__CET__
-3:
-.p2align 3
-4:
-#endif
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/src/libsodium/include/sodium/private/common.h
+++ b/src/libsodium/include/sodium/private/common.h
@@ -16,6 +16,8 @@
 # warning work as expected, and performance is likely to be suboptimal.
 #endif
 
+#ifndef __ASSEMBLER__
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -266,6 +268,20 @@ extern void ct_unpoison(const void *, size_t);
 # define ACQUIRE_FENCE atomic_thread_fence(memory_order_acquire)
 #else
 # define ACQUIRE_FENCE (void) 0
+#endif
+
+#else
+
+/*
+ * Clang got CET (-fcf-protection) support early, but the cet.h header was
+ * added in v11.
+ */
+# if (defined(__GNUC__) && __GNUC__ >= 8) || \
+     (defined(__clang__) && __clang_major__ >= 11)
+#  include <cet.h>
+# else
+#  define _CET_ENDBR
+# endif
 #endif
 
 #endif


### PR DESCRIPTION
Use cet.h if available and use _CET_ENDBR to make all the functions IBT-safe.  This is not directly testable yet, but the instruction is in the nop space for processors that don't support it, so it's a harmless addition.

cet.h also includes the SHSTK and IBT GNU properties in ELF, so remove the manually added ones.

---

Sorry, I missed this in my previous patch because there's no Linux kernel support for IBT yet.  This is a more complete fix to making libsodium properly CET-enabled.