### PR TITLE
Remove retired Lift (muse) service

### DIFF
--- a/.muse/config.toml
+++ b/.muse/config.toml
@@ -1,2 +1,0 @@
-setup = ".muse/setup.sh"
-build = "make"

--- a/.muse/setup.sh
+++ b/.muse/setup.sh
@@ -1,3 +1,0 @@
-#! /bin/sh
-./autogen.sh -s
-env CPPFLAGS="-DDEV_MODE=1" ./configure --disable-dependency-tracking


### PR DESCRIPTION
The Lift (rebranded 'Muse') service is being retired. This PR deletes the configuration but an administrator would need to delete the github application.

Lift ran shellcheck, infer, semgrep, and cobra on this repo. If you'd like to have github actions for any of those then we could work to get open replacements. I've monthly builds of infer going to ghcr and it seems to work for other C projects like [librdkafka](https://github.com/foodforbrain/librdkafka/blob/master/.github/workflows/infer.yml).

EDIT: it appears the app was uninstalled, so we just have these residual files.