### PR TITLE
[Windows] Define TLS as _Thread_local if compiler supports C11 to avoid warnings with Clang-MinGW

### DIFF
--- a/src/libsodium/randombytes/internal/randombytes_internal_random.c
+++ b/src/libsodium/randombytes/internal/randombytes_internal_random.c
@@ -98,7 +98,11 @@ BOOLEAN NTAPI RtlGenRandom(PVOID RandomBuffer, ULONG RandomBufferLength);
 
 #ifndef TLS
 # ifdef _WIN32
-#  define TLS __declspec(thread)
+#  if (defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L)
+#   define TLS _Thread_local
+#  else
+#   define TLS __declspec(thread)
+#  endif
 # else
 #  define TLS
 # endif


### PR DESCRIPTION
Hello hello,

Here I am with a first PR to remove some warnings when compiling on Windows-msys using clang-mingw-ucrt.

This avoids having warnings when compiling with Clang-MinGW on windows. Otherwise I have a warning saying __declspec(thread) is not recognised by clang.exe.

Cheers,
Scr3am