### PR TITLE
Do not redefine  _mm_roti_epi64 if xop feature set enabled

### DIFF
--- a/src/libsodium/crypto_generichash/blake2b/ref/blake2b-compress-sse41.h
+++ b/src/libsodium/crypto_generichash/blake2b/ref/blake2b-compress-sse41.h
@@ -5,18 +5,23 @@
 #define LOADU(p) _mm_loadu_si128((const __m128i *) (const void *) (p))
 #define STOREU(p, r) _mm_storeu_si128((__m128i *) (void *) (p), r)
 
-#define _mm_roti_epi64(x, c)                                         \
-    (-(c) == 32)                                                     \
-        ? _mm_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))            \
-        : (-(c) == 24)                                               \
-              ? _mm_shuffle_epi8((x), r24)                           \
-              : (-(c) == 16)                                         \
-                    ? _mm_shuffle_epi8((x), r16)                     \
-                    : (-(c) == 63)                                   \
-                          ? _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
-                                          _mm_add_epi64((x), (x)))   \
-                          : _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
-                                          _mm_slli_epi64((x), 64 - (-(c))))
+#ifndef __XOP__ // XOP feature set enabled implies _mm_roti_epi64 is existing AFAIK so no need to define the libsodium replacement.
+# ifdef _mm_roti_epi64 // If we have the function macro but not the feature set macro it will fail compiling.
+#  undef _mm_roti_epi64 // So we hide the existing one and use the one provided by libsodium. Hiding avoids warnings for macro redefinitions.
+# endif
+# define _mm_roti_epi64(x, c)                                         \
+     (-(c) == 32)                                                     \
+         ? _mm_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))            \
+         : (-(c) == 24)                                               \
+               ? _mm_shuffle_epi8((x), r24)                           \
+               : (-(c) == 16)                                         \
+                     ? _mm_shuffle_epi8((x), r16)                     \
+                     : (-(c) == 63)                                   \
+                           ? _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
+                                           _mm_add_epi64((x), (x)))   \
+                           : _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
+                                           _mm_slli_epi64((x), 64 - (-(c))))
+#endif
 
 #define G1(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h, b0, b1) \
     row1l = _mm_add_epi64(_mm_add_epi64(row1l, b0), row2l);                \

--- a/src/libsodium/crypto_generichash/blake2b/ref/blake2b-compress-ssse3.h
+++ b/src/libsodium/crypto_generichash/blake2b/ref/blake2b-compress-ssse3.h
@@ -5,18 +5,23 @@
 #define LOADU(p) _mm_loadu_si128((const __m128i *) (const void *) (p))
 #define STOREU(p, r) _mm_storeu_si128((__m128i *) (void *) (p), r)
 
-#define _mm_roti_epi64(x, c)                                         \
-    (-(c) == 32)                                                     \
-        ? _mm_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))            \
-        : (-(c) == 24)                                               \
-              ? _mm_shuffle_epi8((x), r24)                           \
-              : (-(c) == 16)                                         \
-                    ? _mm_shuffle_epi8((x), r16)                     \
-                    : (-(c) == 63)                                   \
-                          ? _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
-                                          _mm_add_epi64((x), (x)))   \
-                          : _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
-                                          _mm_slli_epi64((x), 64 - (-(c))))
+#ifndef __XOP__ // XOP feature set enabled implies _mm_roti_epi64 is existing AFAIK so no need to define the libsodium replacement.
+# ifdef _mm_roti_epi64 // If we have the function macro but not the feature set macro it will fail compiling.
+#  undef _mm_roti_epi64 // So we hide the existing one and use the one provided by libsodium. Hiding avoids warnings for macro redefinitions.
+# endif
+# define _mm_roti_epi64(x, c)                                         \
+     (-(c) == 32)                                                     \
+         ? _mm_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))            \
+         : (-(c) == 24)                                               \
+               ? _mm_shuffle_epi8((x), r24)                           \
+               : (-(c) == 16)                                         \
+                     ? _mm_shuffle_epi8((x), r16)                     \
+                     : (-(c) == 63)                                   \
+                           ? _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
+                                           _mm_add_epi64((x), (x)))   \
+                           : _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
+                                           _mm_slli_epi64((x), 64 - (-(c))))
+#endif
 
 #define G1(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h, b0, b1) \
     row1l = _mm_add_epi64(_mm_add_epi64(row1l, b0), row2l);                \

--- a/src/libsodium/crypto_pwhash/argon2/blamka-round-ssse3.h
+++ b/src/libsodium/crypto_pwhash/argon2/blamka-round-ssse3.h
@@ -8,18 +8,23 @@
     (_mm_setr_epi8(2, 3, 4, 5, 6, 7, 0, 1, 10, 11, 12, 13, 14, 15, 8, 9))
 #define r24 \
     (_mm_setr_epi8(3, 4, 5, 6, 7, 0, 1, 2, 11, 12, 13, 14, 15, 8, 9, 10))
-#define _mm_roti_epi64(x, c)                                         \
-    (-(c) == 32)                                                     \
-        ? _mm_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))            \
-        : (-(c) == 24)                                               \
-              ? _mm_shuffle_epi8((x), r24)                           \
-              : (-(c) == 16)                                         \
-                    ? _mm_shuffle_epi8((x), r16)                     \
-                    : (-(c) == 63)                                   \
-                          ? _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
-                                          _mm_add_epi64((x), (x)))   \
-                          : _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
-                                          _mm_slli_epi64((x), 64 - (-(c))))
+#ifndef __XOP__ // XOP feature set enabled implies _mm_roti_epi64 is existing AFAIK so no need to define the libsodium replacement.
+# ifdef _mm_roti_epi64 // If we have the function macro but not the feature set macro it will fail compiling.
+#  undef _mm_roti_epi64 // So we hide the existing one and use the one provided by libsodium. Hiding avoids warnings for macro redefinitions.
+# endif
+# define _mm_roti_epi64(x, c)                                         \
+     (-(c) == 32)                                                     \
+         ? _mm_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))            \
+         : (-(c) == 24)                                               \
+               ? _mm_shuffle_epi8((x), r24)                           \
+               : (-(c) == 16)                                         \
+                     ? _mm_shuffle_epi8((x), r16)                     \
+                     : (-(c) == 63)                                   \
+                           ? _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
+                                           _mm_add_epi64((x), (x)))   \
+                           : _mm_xor_si128(_mm_srli_epi64((x), -(c)), \
+                                           _mm_slli_epi64((x), 64 - (-(c))))
+#endif
 
 static inline __m128i
 fBlaMka(__m128i x, __m128i y)


### PR DESCRIPTION
Hello,

Me again with another PR to fix some warnings when compiling the library.
This time it is about macro redefinition.

My toolchain has already _mm_roti_epi64 that returns __builtin_ia32_vprotqi.
However it fails if I don't enable the feature set XOP via -mxop but I am targeting a hardware that doesn't have it so instead I decided to change the code as follow:

- if XOP is enabled (we can check it via "__ XOP __") we don't redefine _mm_roti_epi64
- if XOP is not enabled but the macro is already existing in the toolchain headers, we disable the one coming from the toolchain (since it won't work anyway without XOP) before redefining it in libsodium to avoid preprocessor macro redefinition warnings.

I just have one question: is this redefinition due to security reasons ? There is a flaw with the builtin rotation ? Or it is just to make it work on all targets ? I assumed the latter but I could be wrong, not an expert.

That's all.
Cheers,
Scr3am

PS: Should we put _mm_roti_epi64 in its own header file and include it in the 3 headers ? Instead of copy-pasting it 3 times ?