### PR TITLE
Add missing undef in _mm_roti_epi64 definition for blake2b-ssse3

### DIFF
--- a/src/libsodium/crypto_generichash/blake2b/ref/blake2b-compress-ssse3.h
+++ b/src/libsodium/crypto_generichash/blake2b/ref/blake2b-compress-ssse3.h
@@ -6,6 +6,7 @@
 #define STOREU(p, r) _mm_storeu_si128((__m128i *) (void *) (p), r)
 
 #if !(defined(_mm_roti_epi64) && defined(__XOP__))
+#undef  _mm_roti_epi64
 #define _mm_roti_epi64(x, c)                                         \
     (-(c) == 32)                                                     \
         ? _mm_shuffle_epi32((x), _MM_SHUFFLE(2, 3, 0, 1))            \


### PR DESCRIPTION
There is a missing undef when defining _mm_roti_epi64.