### PR TITLE
Support for arbitrary context in ed25519ph

### DIFF
--- a/src/libsodium/crypto_sign/ed25519/ref10/open.c
+++ b/src/libsodium/crypto_sign/ed25519/ref10/open.c
@@ -16,7 +16,9 @@ _crypto_sign_ed25519_verify_detached(const unsigned char *sig,
                                      const unsigned char *m,
                                      unsigned long long   mlen,
                                      const unsigned char *pk,
-                                     int prehashed)
+                                     int prehashed,
+                                     const unsigned char *c,
+                                     unsigned long long clen)
 {
     crypto_hash_sha512_state hs;
     unsigned char            h[64];
@@ -48,7 +50,7 @@ _crypto_sign_ed25519_verify_detached(const unsigned char *sig,
         ge25519_has_small_order(&expected_r) != 0) {
         return -1;
     }
-    _crypto_sign_ed25519_ref10_hinit(&hs, prehashed);
+    _crypto_sign_ed25519_ref10_hinit(&hs, prehashed, c, clen);
     crypto_hash_sha512_update(&hs, sig, 32);
     crypto_hash_sha512_update(&hs, pk, 32);
     crypto_hash_sha512_update(&hs, m, mlen);
@@ -68,7 +70,7 @@ crypto_sign_ed25519_verify_detached(const unsigned char *sig,
                                     unsigned long long   mlen,
                                     const unsigned char *pk)
 {
-    return _crypto_sign_ed25519_verify_detached(sig, m, mlen, pk, 0);
+    return _crypto_sign_ed25519_verify_detached(sig, m, mlen, pk, 0, NULL, 0);
 }
 
 int

--- a/src/libsodium/crypto_sign/ed25519/ref10/sign_ed25519_ref10.h
+++ b/src/libsodium/crypto_sign/ed25519/ref10/sign_ed25519_ref10.h
@@ -4,17 +4,24 @@
 #include "private/quirks.h"
 
 void _crypto_sign_ed25519_ref10_hinit(crypto_hash_sha512_state *hs,
-                                      int prehashed);
+                                      int prehashed,
+                                      const unsigned char *c,
+                                      unsigned long long clen);
 
 int _crypto_sign_ed25519_detached(unsigned char *sig,
                                   unsigned long long *siglen_p,
                                   const unsigned char *m,
                                   unsigned long long mlen,
-                                  const unsigned char *sk, int prehashed);
+                                  const unsigned char *sk,
+                                  int prehashed,
+                                  const unsigned char *c,
+                                  unsigned long long clen);
 
 int _crypto_sign_ed25519_verify_detached(const unsigned char *sig,
                                          const unsigned char *m,
                                          unsigned long long   mlen,
                                          const unsigned char *pk,
-                                         int prehashed);
+                                         int prehashed,
+                                         const unsigned char *c,
+                                         unsigned long long clen);
 #endif

--- a/src/libsodium/crypto_sign/ed25519/sign_ed25519.c
+++ b/src/libsodium/crypto_sign/ed25519/sign_ed25519.c
@@ -61,7 +61,23 @@ int
 crypto_sign_ed25519ph_init(crypto_sign_ed25519ph_state *state)
 {
     crypto_hash_sha512_init(&state->hs);
+    state->context = NULL;
+    state->context_length = 0;
     return 0;
+}
+
+int
+crypto_sign_ed25519ph_set_context(crypto_sign_ed25519ph_state *state,
+                                   const unsigned char *ctx,
+                                   unsigned long long ctxlen)
+{
+    if(ctxlen < 256) {
+        state->context = ctx;
+        state->context_length = ctxlen;
+        return 0;
+    } else {
+        return -1;
+    }
 }
 
 int
@@ -81,7 +97,8 @@ crypto_sign_ed25519ph_final_create(crypto_sign_ed25519ph_state *state,
 
     crypto_hash_sha512_final(&state->hs, ph);
 
-    return _crypto_sign_ed25519_detached(sig, siglen_p, ph, sizeof ph, sk, 1);
+    return _crypto_sign_ed25519_detached(sig, siglen_p, ph, sizeof ph, sk, 1,
+                                         state->context, state->context_length);
 }
 
 int
@@ -93,5 +110,7 @@ crypto_sign_ed25519ph_final_verify(crypto_sign_ed25519ph_state *state,
 
     crypto_hash_sha512_final(&state->hs, ph);
 
-    return _crypto_sign_ed25519_verify_detached(sig, ph, sizeof ph, pk, 1);
+    return _crypto_sign_ed25519_verify_detached(sig, ph, sizeof ph, pk, 1,
+                                                state->context,
+                                                state->context_length);
 }

--- a/src/libsodium/include/sodium/crypto_sign_ed25519.h
+++ b/src/libsodium/include/sodium/crypto_sign_ed25519.h
@@ -14,6 +14,8 @@ extern "C" {
 
 typedef struct crypto_sign_ed25519ph_state {
     crypto_hash_sha512_state hs;
+    const unsigned char *context;
+    unsigned long long context_length;
 } crypto_sign_ed25519ph_state;
 
 SODIUM_EXPORT
@@ -96,6 +98,12 @@ int crypto_sign_ed25519_sk_to_pk(unsigned char *pk, const unsigned char *sk)
 
 SODIUM_EXPORT
 int crypto_sign_ed25519ph_init(crypto_sign_ed25519ph_state *state)
+            __attribute__ ((nonnull));
+
+SODIUM_EXPORT
+int crypto_sign_ed25519ph_set_context(crypto_sign_ed25519ph_state *state,
+                                      const unsigned char *ctx,
+                                      unsigned long long ctxlen)
             __attribute__ ((nonnull));
 
 SODIUM_EXPORT


### PR DESCRIPTION
Hi,

this pr adds support for arbitrary context in ed25519ph. This is required for compatibility with the crypto system being implemented by veilid.

It introduces a new API to set that context, but keep compatibility with all existing API. Not using this API maintains perfect compatibility with the current behaviour. The only side effect is a change to the size of crypto_sign_ed25519ph_state.

I can imagine another solution that does not change the size of crypto_sign_ed25519ph_state but rather introduces two new functions that takes the context as parameter and pass it directly to the underlying functions, so that users can sign and verify with a context. I find this version less elegant, and it would introduce more nesting of internal functions, but I can do it on request.

Please tell me how this pull request can be merged. This is just an initial state, so people can see my intention. I am open to any change.

Thank you.