### PR TITLE
fix(aarch64): Move target #pragma after arm_neon.h include

### DIFF
--- a/src/libsodium/crypto_aead/aes256gcm/armcrypto/aead_aes256gcm_armcrypto.c
+++ b/src/libsodium/crypto_aead/aes256gcm/armcrypto/aead_aes256gcm_armcrypto.c
@@ -19,12 +19,6 @@
 #define __vectorcall
 #endif
 
-#ifdef __clang__
-#pragma clang attribute push(__attribute__((target("neon,crypto,aes"))), apply_to = function)
-#elif defined(__GNUC__)
-#pragma GCC target("+simd+crypto")
-#endif
-
 #ifndef __ARM_FEATURE_CRYPTO
 #define __ARM_FEATURE_CRYPTO 1
 #endif
@@ -33,6 +27,12 @@
 #endif
 
 #include <arm_neon.h>
+
+#ifdef __clang__
+#pragma clang attribute push(__attribute__((target("neon,crypto,aes"))), apply_to = function)
+#elif defined(__GNUC__)
+#pragma GCC target("+simd+crypto")
+#endif
 
 #define ABYTES    crypto_aead_aes256gcm_ABYTES
 #define NPUBBYTES crypto_aead_aes256gcm_NPUBBYTES


### PR DESCRIPTION
Hello,

I'm submitting a fix for https://github.com/jedisct1/libsodium/issues/1314 that was root caused and suggested in https://github.com/android/ndk/issues/1945

Currently the #pragma attribute push is done before including arm_neon.h  
In NDK r26, this can cause the attribute to override and apply to the functions inside arm_neon.h

I've build-tested this patch on desktop and mobile platforms