### PR TITLE
build.zig  can now be used with zig-0.11 and zig-0.12

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -247,12 +247,15 @@ pub fn build(b: *std.build.Builder) !void {
             const name = entry.basename;
             if (mem.endsWith(u8, name, ".c")) {
                 const full_path = try fmt.allocPrint(allocator, "{s}/{s}", .{ src_path, entry.path });
-                lib.addCSourceFiles(&.{full_path}, &.{
-                    "-fvisibility=hidden",
-                    "-fno-strict-aliasing",
-                    "-fno-strict-overflow",
-                    "-fwrapv",
-                    "-flax-vector-conversions",
+                lib.addCSourceFile(.{
+                    .file = .{ .path = full_path },
+                    .flags = &.{
+                        "-fvisibility=hidden",
+                        "-fno-strict-aliasing",
+                        "-fno-strict-overflow",
+                        "-fwrapv",
+                        "-flax-vector-conversions",
+                    },
                 });
             } else if (mem.endsWith(u8, name, ".S")) {
                 const full_path = try fmt.allocPrint(allocator, "{s}/{s}", .{ src_path, entry.path });
@@ -291,7 +294,10 @@ pub fn build(b: *std.build.Builder) !void {
             exe.addIncludePath(.{ .path = "src/libsodium/include" });
             exe.addIncludePath(.{ .path = "test/quirks" });
             const full_path = try fmt.allocPrint(allocator, "{s}/{s}", .{ test_path, entry.path });
-            exe.addCSourceFiles(&.{full_path}, &.{});
+            exe.addCSourceFile(.{
+                .file = .{ .path = full_path },
+                .flags = &.{},
+            });
 
             if (enable_benchmarks) {
                 exe.defineCMacro("BENCHMARKS", "1");


### PR DESCRIPTION
I adapted the build.zig file which did not compile under zig-0.12, now it can be used by 0.11 and 0.12