### PR TITLE
Move includes in crypto_onetimeauth_poly1305.h outside of extern C

### DIFF
--- a/src/libsodium/include/sodium/crypto_onetimeauth_poly1305.h
+++ b/src/libsodium/include/sodium/crypto_onetimeauth_poly1305.h
@@ -1,13 +1,6 @@
 #ifndef crypto_onetimeauth_poly1305_H
 #define crypto_onetimeauth_poly1305_H
 
-#ifdef __cplusplus
-# ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wlong-long"
-# endif
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,6 +8,13 @@ extern "C" {
 #include <sys/types.h>
 
 #include "export.h"
+
+#ifdef __cplusplus
+# ifdef __GNUC__
+#  pragma GCC diagnostic ignored "-Wlong-long"
+# endif
+extern "C" {
+#endif
 
 typedef struct CRYPTO_ALIGN(16) crypto_onetimeauth_poly1305_state {
     unsigned char opaque[256];


### PR DESCRIPTION
Includes being outside of `extern "C"` are de-facto standard in all other include files of libsodium.

At the same time, having inside the `extern "C"` is causing problem with C++ vs. C toolchain being confused about which libraries should be linked. This was especially painful while working on `swift-sodium` integration with windows.