### PR TITLE
fixed inability to create xcframework in Symbolic Link

### DIFF
--- a/dist-build/apple-xcframework.sh
+++ b/dist-build/apple-xcframework.sh
@@ -477,16 +477,16 @@ for f in macos ios watchos tvos visionos catalyst; do
   if [ "$VISIONOS_SUPPORTED" = false ] && [ "$f" = "visionos" ]; then
     continue
   fi
-  XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -library ${PREFIX}/${f}/lib/libsodium.a"
-  XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -headers ${PREFIX}/${f}/include"
+  XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -library $(readlink -f ${PREFIX}/${f}/lib/libsodium.a)"
+  XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -headers $(readlink -f ${PREFIX}/${f}/include)"
 done
 if [ -z "$LIBSODIUM_SKIP_SIMULATORS" ]; then
   for f in ios-simulators watchos-simulators tvos-simulators visionos-simulators; do
     if [ "$VISIONOS_SUPPORTED" = false ] && [ "$f" = "visionos-simulators" ]; then
       continue
     fi
-    XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -library ${PREFIX}/${f}/lib/libsodium.a"
-    XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -headers ${PREFIX}/${f}/include"
+    XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -library $(readlink -f ${PREFIX}/${f}/lib/libsodium.a)"
+    XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -headers $(readlink -f ${PREFIX}/${f}/include)"
   done
 fi
 xcodebuild -create-xcframework \


### PR DESCRIPTION
```
Creating Clibsodium.xcframework...
error: cannot compute path of binary 'Path(str: "/private/tmp/libsodium-stable/libsodium-apple/macos/lib/libsodium.a")' relative to that of '/tmp/libsodium-stable/libsodium-apple/macos/lib/libsodium.a' ls: /tmp/libsodium-stable/libsodium-apple/Clibsodium.xcframework: No such file or directory
```
```
ls -l /tmp
lrwxr-xr-x@ 1 root  wheel  11 12 15 22:43 /tmp -> private/tmp
```