### PR TITLE
Support for `netX-maccatalyst` TFM in .NET

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -118,9 +118,6 @@ jobs:
       - name: tests
         run: |
           cd zig-out/bin && ./run.sh
-      - name: debug-ls
-        run: |
-          ls -l -R zig-out/
       - uses: actions/upload-artifact@v3
         with:
           name: build-linux-musl-x64
@@ -137,9 +134,6 @@ jobs:
       - name: build
         run: |
           zig build -Doptimize=ReleaseFast -Dtarget=arm-linux-musleabihf -Dcpu=baseline
-      - name: debug-ls
-        run: |
-          ls -l -R zig-out/
       - uses: actions/upload-artifact@v3
         with:
           name: build-linux-musl-arm
@@ -272,9 +266,6 @@ jobs:
           path: .libsodium-pack/runtimes/maccatalyst-arm64/native/
       - name: Copy files
         run: cp AUTHORS ChangeLog LICENSE packaging/dotnet-core/libsodium.pkgproj .libsodium-pack/
-      - name: debug-ls
-        run: |
-          ls -l -R .libsodium-pack/
       - name: Create NuGet package
         run: dotnet pack -c Release .libsodium-pack/libsodium.pkgproj
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -118,10 +118,13 @@ jobs:
       - name: tests
         run: |
           cd zig-out/bin && ./run.sh
+      - name: debug-ls
+        run: |
+          ls -l -R zig-out/
       - uses: actions/upload-artifact@v3
         with:
           name: build-linux-musl-x64
-          path: zig-out/lib/libsodium.so
+          path: zig-out/lib/libsodium.a
 
   build-linux-musl-arm:
     runs-on: ubuntu-latest
@@ -134,10 +137,13 @@ jobs:
       - name: build
         run: |
           zig build -Doptimize=ReleaseFast -Dtarget=arm-linux-musleabihf -Dcpu=baseline
+      - name: debug-ls
+        run: |
+          ls -l -R zig-out/
       - uses: actions/upload-artifact@v3
         with:
           name: build-linux-musl-arm
-          path: zig-out/lib/libsodium.so
+          path: zig-out/lib/libsodium.a
 
   build-linux-musl-arm64:
     runs-on: ubuntu-latest
@@ -153,12 +159,20 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: build-linux-musl-arm64
-          path: zig-out/lib/libsodium.so
+          path: zig-out/lib/libsodium.a
 
   build-apple:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Automake
+        run: |
+          brew update
+          brew install automake
+      - name: Autogen
+        run: ./autogen.sh -s
+      - name: Configure
+        run: ./configure
       - name: build-xcframework
         run: env LIBSODIUM_FULL_BUILD=1 LIBSODIUM_SKIP_SIMULATORS=1 dist-build/apple-xcframework.sh
       - uses: actions/upload-artifact@v3
@@ -258,6 +272,9 @@ jobs:
           path: .libsodium-pack/runtimes/maccatalyst-arm64/native/
       - name: Copy files
         run: cp AUTHORS ChangeLog LICENSE packaging/dotnet-core/libsodium.pkgproj .libsodium-pack/
+      - name: debug-ls
+        run: |
+          ls -l -R .libsodium-pack/
       - name: Create NuGet package
         run: dotnet pack -c Release .libsodium-pack/libsodium.pkgproj
       - uses: actions/upload-artifact@v3

--- a/packaging/dotnet-core/libsodium.pkgproj
+++ b/packaging/dotnet-core/libsodium.pkgproj
@@ -34,7 +34,9 @@
     <Content Include="runtimes/linux-musl-arm/native/libsodium.so" PackagePath="runtimes/linux-musl-arm/native/" />
     <Content Include="runtimes/linux-musl-arm64/native/libsodium.so" PackagePath="runtimes/linux-musl-arm64/native/" />
     <Content Include="runtimes/osx-x64/native/libsodium.dylib" PackagePath="runtimes/osx-x64/native/" />
-    <Content Include="runtimes/osx-arm64/native/libsodium.dylib" PackagePath="runtimes/osx-arm64/native/" />    
+    <Content Include="runtimes/osx-arm64/native/libsodium.dylib" PackagePath="runtimes/osx-arm64/native/" />
+    <Content Include="runtimes/maccatalyst-x64/native/libsodium.a" PackagePath="runtimes/maccatalyst-x64/native/" />
+    <Content Include="runtimes/maccatalyst-arm64/native/libsodium.a" PackagePath="runtimes/maccatalyst-arm64/native/" />
   </ItemGroup>
 
 </Project>

--- a/packaging/dotnet-core/libsodium.pkgproj
+++ b/packaging/dotnet-core/libsodium.pkgproj
@@ -30,11 +30,11 @@
     <Content Include="runtimes/linux-x64/native/libsodium.so" PackagePath="runtimes/linux-x64/native/" />
     <Content Include="runtimes/linux-arm/native/libsodium.so" PackagePath="runtimes/linux-arm/native/" />
     <Content Include="runtimes/linux-arm64/native/libsodium.so" PackagePath="runtimes/linux-arm64/native/" />
-    <Content Include="runtimes/linux-musl-x64/native/libsodium.so" PackagePath="runtimes/linux-musl-x64/native/" />
-    <Content Include="runtimes/linux-musl-arm/native/libsodium.so" PackagePath="runtimes/linux-musl-arm/native/" />
-    <Content Include="runtimes/linux-musl-arm64/native/libsodium.so" PackagePath="runtimes/linux-musl-arm64/native/" />
-    <Content Include="runtimes/osx-x64/native/libsodium.dylib" PackagePath="runtimes/osx-x64/native/" />
-    <Content Include="runtimes/osx-arm64/native/libsodium.dylib" PackagePath="runtimes/osx-arm64/native/" />
+    <Content Include="runtimes/linux-musl-x64/native/libsodium.a" PackagePath="runtimes/linux-musl-x64/native/" />
+    <Content Include="runtimes/linux-musl-arm/native/libsodium.a" PackagePath="runtimes/linux-musl-arm/native/" />
+    <Content Include="runtimes/linux-musl-arm64/native/libsodium.a" PackagePath="runtimes/linux-musl-arm64/native/" />
+    <Content Include="runtimes/osx-x64/native/libsodium.a" PackagePath="runtimes/osx-x64/native/" />
+    <Content Include="runtimes/osx-arm64/native/libsodium.a" PackagePath="runtimes/osx-arm64/native/" />
     <Content Include="runtimes/maccatalyst-x64/native/libsodium.a" PackagePath="runtimes/maccatalyst-x64/native/" />
     <Content Include="runtimes/maccatalyst-arm64/native/libsodium.a" PackagePath="runtimes/maccatalyst-arm64/native/" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds support for using libsodium in Mac Catalyst .NET projects.

## Testing

I was testing this PR on my `next` branch (https://github.com/MartyIX/libsodium/actions/runs/8745576446) and it created: [nuget-package](https://github.com/MartyIX/libsodium/actions/runs/8745576446/artifacts/1427739121)

The nuget package can be tested with my demo application on Mac Catalyst: 

https://github.com/MartyIX/MaccatalystLibsodium

The only modified file in the "empty Mac Catalyst" project is this file: https://github.com/MartyIX/MaccatalystLibsodium/blob/main/MaccatalystLibsodium/AppDelegate.cs where I added some calls into libsodium library.

### Screenshot

<img width="1136" alt="image" src="https://github.com/jedisct1/libsodium/assets/203266/c07d4ceb-aa8c-471d-b681-7a3b65101c30">
 

## Resources

* https://github.com/jedisct1/libsodium/discussions/1235#discussioncomment-4443263
* https://github.com/jedisct1/libsodium/pull/1238#issuecomment-1383111044