### PR TITLE
Help MSVC optimize ROL/ROR functions

### DIFF
--- a/src/libsodium/include/sodium/private/common.h
+++ b/src/libsodium/include/sodium/private/common.h
@@ -32,6 +32,15 @@ typedef unsigned uint128_t __attribute__((mode(TI)));
 # endif
 #endif
 
+# if defined(_MSC_VER)
+
+#define ROTL32(X, B) _rotl((X), (B))
+#define ROTL64(X, B) _rotl64((X), (B))
+#define ROTR32(X, B) _rotr((X), (B))
+#define ROTR64(X, B) _rotr64((X), (B))
+
+#else
+
 #define ROTL32(X, B) rotl32((X), (B))
 static inline uint32_t
 rotl32(const uint32_t x, const int b)
@@ -59,6 +68,8 @@ rotr64(const uint64_t x, const int b)
 {
     return (x >> b) | (x << (64 - b));
 }
+
+#endif
 
 #define LOAD64_LE(SRC) load64_le(SRC)
 static inline uint64_t


### PR DESCRIPTION
Latest MSVC (Visual Studio 2022) doesn't seem to optimize ROL/ROR functions well.

For clear example, for officially released pre-complied binaries (https://download.libsodium.org/libsodium/releases/),
I compared `blake2b_compress_ref()`, which uses ROL/ROR functions from `private/common.h` a lot.
```c
int
blake2b_compress_ref(blake2b_state *S, const uint8_t block[BLAKE2B_BLOCKBYTES])
{
   ...

#define G(r, i, a, b, c, d)                      \
    do {                                         \
        a += b + m[blake2b_sigma[r][2 * i + 0]]; \
        d = ROTR64(d ^ a, 32);                   \
        c += d;                                  \
        b = ROTR64(b ^ c, 24);                   \
        a += b + m[blake2b_sigma[r][2 * i + 1]]; \
        d = ROTR64(d ^ a, 16);                   \
        c += d;                                  \
        b = ROTR64(b ^ c, 63);                   \
    } while (0)
#define ROUND(r)                           \
    do {                                   \
        G(r, 0, v[0], v[4], v[8], v[12]);  \
        G(r, 1, v[1], v[5], v[9], v[13]);  \
        G(r, 2, v[2], v[6], v[10], v[14]); \
        G(r, 3, v[3], v[7], v[11], v[15]); \
        G(r, 4, v[0], v[5], v[10], v[15]); \
        G(r, 5, v[1], v[6], v[11], v[12]); \
        G(r, 6, v[2], v[7], v[8], v[13]);  \
        G(r, 7, v[3], v[4], v[9], v[14]);  \
    } while (0)
    ROUND(0);
    ...
}
```

- libsodium-1.0.18-stable-msvc\libsodium\x64\Release\v143\dynamic\libsodium.dll
![image](https://github.com/user-attachments/assets/8fbebd48-6216-4085-8a47-04e0911b816e)
- libsodium-1.0.20-stable-mingw\libsodium-win64\bin\libsodium-26.dll
![image](https://github.com/user-attachments/assets/5f85f5d8-cc51-4432-adba-78e969e4fca1)
- libsodium-1.0.20-stable-msvc\libsodium\x64\Release\v143\dynamic\libsodium.dll
![image](https://github.com/user-attachments/assets/ad7f1d75-45a8-4705-ac76-0c757e2e63b3)


You can see that `1.0.20-stable-msvc` uses two shift instructions and a single OR instruction, while others uses just a single ROL/ROR instruction.

I've also tried some comparisons with GCC/Clang, this strange behavior seems to be show on only Latest MSVC (Visual Studio 2022).
This behavior makes the single core performance (i7-14700K) of `blake2b_compress_ref` approximately 1.5 times slower, which is considerable.


So I suggest to use `_rotl`, `_rotl64`, `_rotr`, `_rotr64` [(Reference)](https://learn.microsoft.com/ko-kr/cpp/c-runtime-library/reference/rotl-rotl64-rotr-rotr64) for MSVC to help optimize ROL/ROR functions well.

Thank you.