### PR TITLE
Support for Cloudflare Workers for javascript_stir

### DIFF
--- a/src/libsodium/randombytes/randombytes.c
+++ b/src/libsodium/randombytes/randombytes.c
@@ -57,6 +57,8 @@ javascript_stir(void)
             try {
                 var window_ = 'object' === typeof window ? window : self;
                 var crypto_ = typeof window_.crypto !== 'undefined' ? window_.crypto : window_.msCrypto;
+                // Cloudflare Workers support 
+                crypto_ = (crypto_ === undefined) ? crypto : crypto_;
                 var randomValuesStandard = function() {
                     var buf = new Uint32Array(1);
                     crypto_.getRandomValues(buf);

--- a/src/libsodium/randombytes/randombytes.c
+++ b/src/libsodium/randombytes/randombytes.c
@@ -57,7 +57,6 @@ javascript_stir(void)
             try {
                 var window_ = 'object' === typeof window ? window : self;
                 var crypto_ = typeof window_.crypto !== 'undefined' ? window_.crypto : window_.msCrypto;
-                // Cloudflare Workers support 
                 crypto_ = (crypto_ === undefined) ? crypto : crypto_;
                 var randomValuesStandard = function() {
                     var buf = new Uint32Array(1);


### PR DESCRIPTION
As Cloudflare Workers directly provides the crypto API https://developers.cloudflare.com/workers/runtime-apis/web-crypto/
I added an additional check in `javascript_stir` to use the available crypto API.

Example usage in a Worker would be:
```
export default {
  async fetch(request,env,context) {    
    const _sodium = await import("libsodium-wrappers");
    await _sodium.ready;
    let binkey = _sodium.from_base64(env.PUBKEY, _sodium.base64_variants.ORIGINAL)
    return new Response('Hello');
  }
};
```
