### PR TITLE
Also zeroize registers on sodium_memzero

### DIFF
--- a/src/libsodium/sodium/utils.c
+++ b/src/libsodium/sodium/utils.c
@@ -96,6 +96,10 @@ void *alloca (size_t);
 # define MADV_DONTDUMP MADV_NOCORE
 #endif
 
+#if defined(__GNUC__) && __GNUC__ >= 11
+#  define HAVE_ZERO_CALL_USED_REGS
+#endif
+
 #ifndef DEFAULT_PAGE_SIZE
 # ifdef PAGE_SIZE
 #  define DEFAULT_PAGE_SIZE PAGE_SIZE
@@ -122,6 +126,9 @@ _sodium_dummy_symbol_to_prevent_memzero_lto(void *const  pnt,
 #endif
 /* LCOV_EXCL_STOP */
 
+#ifdef HAVE_ZERO_CALL_USED_REGS
+__attribute__((zero_call_used_regs("all")))
+#endif
 void
 sodium_memzero(void * const pnt, const size_t len)
 {


### PR DESCRIPTION
References:

- [Zeroing buffers is insufficient](https://www.daemonology.net/blog/2014-09-06-zeroing-buffers-is-insufficient.html)
- [Security Improvements in GCC](https://lpc.events/event/11/contributions/1001/attachments/882/1690/LPC_security_gcc_temp.pdf)

sodium_memzero.s

```
	.arch armv8-a
	.file	"sodium_memzero.c"
	.text
	.align	2
	.global	sodium_memzero
	.type	sodium_memzero, %function
sodium_memzero:
.LFB0:
	.cfi_startproc
	sub	sp, sp, #32
	.cfi_def_cfa_offset 32
	str	x0, [sp, 8]
	str	x1, [sp]
	ldr	x0, [sp, 8]
	str	x0, [sp, 16]
	str	xzr, [sp, 24]
	b	.L2
.L3:
	ldr	x1, [sp, 16]
	ldr	x0, [sp, 24]
	add	x2, x0, 1
	str	x2, [sp, 24]
	add	x0, x1, x0
	strb	wzr, [x0]
.L2:
	ldr	x1, [sp, 24]
	ldr	x0, [sp]
	cmp	x1, x0
	bcc	.L3
	nop
	nop
	add	sp, sp, 32
	.cfi_def_cfa_offset 0
	mov	x0, 0
	mov	x1, 0
	mov	x2, 0
	mov	x3, 0
	mov	x4, 0
	mov	x5, 0
	mov	x6, 0
	mov	x7, 0
	mov	x8, 0
	mov	x9, 0
	mov	x10, 0
	mov	x11, 0
	mov	x12, 0
	mov	x13, 0
	mov	x14, 0
	mov	x15, 0
	mov	x16, 0
	mov	x17, 0
	mov	x18, 0
	movi	v0.2d, #0
	movi	v1.2d, #0
	movi	v2.2d, #0
	movi	v3.2d, #0
	movi	v4.2d, #0
	movi	v5.2d, #0
	movi	v6.2d, #0
	movi	v7.2d, #0
	movi	v16.2d, #0
	movi	v17.2d, #0
	movi	v18.2d, #0
	movi	v19.2d, #0
	movi	v20.2d, #0
	movi	v21.2d, #0
	movi	v22.2d, #0
	movi	v23.2d, #0
	movi	v24.2d, #0
	movi	v25.2d, #0
	movi	v26.2d, #0
	movi	v27.2d, #0
	movi	v28.2d, #0
	movi	v29.2d, #0
	movi	v30.2d, #0
	movi	v31.2d, #0
	ret
	.cfi_endproc
.LFE0:
	.size	sodium_memzero, .-sodium_memzero
	.ident	"GCC: (Debian 12.2.0-14) 12.2.0"
	.section	.note.GNU-stack,"",@progbits
```