### PR TITLE
blake2b: Add aarch64 NEON acceleration

### DIFF
--- a/src/libsodium/Makefile.am
+++ b/src/libsodium/Makefile.am
@@ -35,6 +35,9 @@ libsodium_la_SOURCES = \
 	crypto_generichash/blake2b/generichash_blake2.c \
 	crypto_generichash/blake2b/ref/blake2.h \
 	crypto_generichash/blake2b/ref/blake2b-compress-ref.c \
+	crypto_generichash/blake2b/ref/blake2b-compress-neon.c \
+	crypto_generichash/blake2b/ref/blake2b-compress-neon.h \
+	crypto_generichash/blake2b/ref/blake2b-load-neon.h \
 	crypto_generichash/blake2b/ref/blake2b-load-sse2.h \
 	crypto_generichash/blake2b/ref/blake2b-load-sse41.h \
 	crypto_generichash/blake2b/ref/blake2b-load-avx2.h \

--- a/src/libsodium/crypto_generichash/blake2b/ref/blake2.h
+++ b/src/libsodium/crypto_generichash/blake2b/ref/blake2.h
@@ -103,5 +103,7 @@ int blake2b_compress_sse41(blake2b_state *S,
                            const uint8_t  block[BLAKE2B_BLOCKBYTES]);
 int blake2b_compress_avx2(blake2b_state *S,
                           const uint8_t  block[BLAKE2B_BLOCKBYTES]);
+int blake2b_compress_neon(blake2b_state *S,
+                          const uint8_t  block[BLAKE2B_BLOCKBYTES]);
 
 #endif

--- a/src/libsodium/crypto_generichash/blake2b/ref/blake2b-compress-neon.c
+++ b/src/libsodium/crypto_generichash/blake2b/ref/blake2b-compress-neon.c
@@ -1,0 +1,85 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+*/
+
+#include <stdint.h>
+#include <string.h>
+
+#include "blake2.h"
+#include "private/common.h"
+
+#if defined(__aarch64__)
+
+# include <arm_neon.h>
+
+# include "blake2b-compress-neon.h"
+
+CRYPTO_ALIGN(64)
+static const uint64_t blake2b_IV[8] = {
+    0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL, 0x3c6ef372fe94f82bULL,
+    0xa54ff53a5f1d36f1ULL, 0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL,
+    0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL
+};
+
+int
+blake2b_compress_neon(blake2b_state *S,
+                      const uint8_t  block[BLAKE2B_BLOCKBYTES])
+{
+    uint64x2_t    row1l, row1h;
+    uint64x2_t    row2l, row2h;
+    uint64x2_t    row3l, row3h;
+    uint64x2_t    row4l, row4h;
+    uint64x2_t    b0, b1;
+    uint64x2_t    t0, t1;
+
+    const uint64x2_t m0 = vreinterpretq_u64_u8(vld1q_u8(block + 00));
+    const uint64x2_t m1 = vreinterpretq_u64_u8(vld1q_u8(block + 16));
+    const uint64x2_t m2 = vreinterpretq_u64_u8(vld1q_u8(block + 32));
+    const uint64x2_t m3 = vreinterpretq_u64_u8(vld1q_u8(block + 48));
+    const uint64x2_t m4 = vreinterpretq_u64_u8(vld1q_u8(block + 64));
+    const uint64x2_t m5 = vreinterpretq_u64_u8(vld1q_u8(block + 80));
+    const uint64x2_t m6 = vreinterpretq_u64_u8(vld1q_u8(block + 96));
+    const uint64x2_t m7 = vreinterpretq_u64_u8(vld1q_u8(block + 112));
+
+    const uint64x2_t h0 = row1l = vld1q_u64(&S->h[0]);
+    const uint64x2_t h1 = row1h = vld1q_u64(&S->h[2]);
+    const uint64x2_t h2 = row2l = vld1q_u64(&S->h[4]);
+    const uint64x2_t h3 = row2h = vld1q_u64(&S->h[6]);
+
+    row3l = vld1q_u64(&blake2b_IV[0]);
+    row3h = vld1q_u64(&blake2b_IV[2]);
+    row4l = veorq_u64(vld1q_u64(&blake2b_IV[4]), vld1q_u64(&S->t[0]));
+    row4h = veorq_u64(vld1q_u64(&blake2b_IV[6]), vld1q_u64(&S->f[0]));
+
+    ROUND(0);
+    ROUND(1);
+    ROUND(2);
+    ROUND(3);
+    ROUND(4);
+    ROUND(5);
+    ROUND(6);
+    ROUND(7);
+    ROUND(8);
+    ROUND(9);
+    ROUND(10);
+    ROUND(11);
+
+    vst1q_u64(&S->h[0], veorq_u64(h0, veorq_u64(row1l, row3l)));
+    vst1q_u64(&S->h[2], veorq_u64(h1, veorq_u64(row1h, row3h)));
+    vst1q_u64(&S->h[4], veorq_u64(h2, veorq_u64(row2l, row4l)));
+    vst1q_u64(&S->h[6], veorq_u64(h3, veorq_u64(row2h, row4h)));
+    return 0;
+}
+
+#endif

--- a/src/libsodium/crypto_generichash/blake2b/ref/blake2b-compress-neon.h
+++ b/src/libsodium/crypto_generichash/blake2b/ref/blake2b-compress-neon.h
@@ -1,0 +1,123 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+*/
+
+#ifndef blake2b_compress_neon_H
+#define blake2b_compress_neon_H
+
+#define G1(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h, b0, b1)    \
+    do {                                                                      \
+        row1l = vaddq_u64(vaddq_u64(row1l, b0), row2l);                       \
+        row1h = vaddq_u64(vaddq_u64(row1h, b1), row2h);                       \
+        row4l = veorq_u64(row4l, row1l);                                      \
+        row4h = veorq_u64(row4h, row1h);                                      \
+        row4l = vreinterpretq_u64_u32(                                        \
+            vrev64q_u32(vreinterpretq_u32_u64(row4l)));                       \
+        row4h = vreinterpretq_u64_u32(                                        \
+            vrev64q_u32(vreinterpretq_u32_u64(row4h)));                       \
+        row3l = vaddq_u64(row3l, row4l);                                      \
+        row3h = vaddq_u64(row3h, row4h);                                      \
+        row2l = veorq_u64(row2l, row3l);                                      \
+        row2h = veorq_u64(row2h, row3h);                                      \
+        row2l = vcombine_u64(                                                 \
+            vreinterpret_u64_u8(vext_u8(                                      \
+                vreinterpret_u8_u64(vget_low_u64(row2l)),                     \
+                vreinterpret_u8_u64(vget_low_u64(row2l)), 3)),                \
+            vreinterpret_u64_u8(vext_u8(                                      \
+                vreinterpret_u8_u64(vget_high_u64(row2l)),                    \
+                vreinterpret_u8_u64(vget_high_u64(row2l)), 3)));              \
+        row2h = vcombine_u64(                                                 \
+            vreinterpret_u64_u8(vext_u8(                                      \
+                vreinterpret_u8_u64(vget_low_u64(row2h)),                     \
+                vreinterpret_u8_u64(vget_low_u64(row2h)), 3)),                \
+            vreinterpret_u64_u8(vext_u8(                                      \
+                vreinterpret_u8_u64(vget_high_u64(row2h)),                    \
+                vreinterpret_u8_u64(vget_high_u64(row2h)), 3)));              \
+    } while(0)
+
+#define G2(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h, b0, b1)    \
+    do {                                                                      \
+        row1l = vaddq_u64(vaddq_u64(row1l, b0), row2l);                       \
+        row1h = vaddq_u64(vaddq_u64(row1h, b1), row2h);                       \
+        row4l = veorq_u64(row4l, row1l);                                      \
+        row4h = veorq_u64(row4h, row1h);                                      \
+        row4l = vcombine_u64(                                                 \
+            vreinterpret_u64_u8(vext_u8(                                      \
+                vreinterpret_u8_u64(vget_low_u64(row4l)),                     \
+                vreinterpret_u8_u64(vget_low_u64(row4l)), 2)),                \
+            vreinterpret_u64_u8(vext_u8(                                      \
+                vreinterpret_u8_u64(vget_high_u64(row4l)),                    \
+                vreinterpret_u8_u64(vget_high_u64(row4l)), 2)));              \
+        row4h = vcombine_u64(                                                 \
+            vreinterpret_u64_u8(vext_u8(                                      \
+                vreinterpret_u8_u64(vget_low_u64(row4h)),                     \
+                vreinterpret_u8_u64(vget_low_u64(row4h)), 2)),                \
+            vreinterpret_u64_u8(vext_u8(                                      \
+                vreinterpret_u8_u64(vget_high_u64(row4h)),                    \
+                vreinterpret_u8_u64(vget_high_u64(row4h)), 2)));              \
+        row3l = vaddq_u64(row3l, row4l);                                      \
+        row3h = vaddq_u64(row3h, row4h);                                      \
+        row2l = veorq_u64(row2l, row3l);                                      \
+        row2h = veorq_u64(row2h, row3h);                                      \
+        row2l = veorq_u64(vaddq_u64(row2l, row2l), vshrq_n_u64(row2l, 63));   \
+        row2h = veorq_u64(vaddq_u64(row2h, row2h), vshrq_n_u64(row2h, 63));   \
+    } while(0)
+
+#define DIAGONALIZE(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h)   \
+    do {                                                                      \
+        t0 = vextq_u64(row2l, row2h, 1);                                      \
+        t1 = vextq_u64(row2h, row2l, 1);                                      \
+        row2l = t0;                                                           \
+        row2h = t1;                                                           \
+        t0 = row3l;                                                           \
+        row3l = row3h;                                                        \
+        row3h = t0;                                                           \
+        t0 = vextq_u64(row4h, row4l, 1);                                      \
+        t1 = vextq_u64(row4l, row4h, 1);                                      \
+        row4l = t0;                                                           \
+        row4h = t1;                                                           \
+    } while(0)
+
+#define UNDIAGONALIZE(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h) \
+    do {                                                                      \
+        t0 = vextq_u64(row2h, row2l, 1);                                      \
+        t1 = vextq_u64(row2l, row2h, 1);                                      \
+        row2l = t0;                                                           \
+        row2h = t1;                                                           \
+        t0 = row3l;                                                           \
+        row3l = row3h;                                                        \
+        row3h = t0;                                                           \
+        t0 = vextq_u64(row4l, row4h, 1);                                      \
+        t1 = vextq_u64(row4h, row4l, 1);                                      \
+        row4l = t0;                                                           \
+        row4h = t1;                                                           \
+    } while(0)
+
+#include "blake2b-load-neon.h"
+
+#define ROUND(r)                                                              \
+    do {                                                                      \
+        LOAD_MSG_ ##r ##_1(b0, b1);                                           \
+        G1(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h, b0, b1);   \
+        LOAD_MSG_ ##r ##_2(b0, b1);                                           \
+        G2(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h, b0, b1);   \
+        DIAGONALIZE(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h);  \
+        LOAD_MSG_ ##r ##_3(b0, b1);                                           \
+        G1(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h, b0, b1);   \
+        LOAD_MSG_ ##r ##_4(b0, b1);                                           \
+        G2(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h, b0, b1);   \
+        UNDIAGONALIZE(row1l, row2l, row3l, row4l, row1h, row2h, row3h, row4h);\
+    } while(0)
+
+#endif

--- a/src/libsodium/crypto_generichash/blake2b/ref/blake2b-load-neon.h
+++ b/src/libsodium/crypto_generichash/blake2b/ref/blake2b-load-neon.h
@@ -1,0 +1,307 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+*/
+
+#ifndef blake2b_load_neon_H
+#define blake2b_load_neon_H
+
+#define LOAD_MSG_0_1(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m0), vget_low_u64(m1));       \
+        b1 = vcombine_u64(vget_low_u64(m2), vget_low_u64(m3));       \
+    } while(0)
+
+#define LOAD_MSG_0_2(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m0), vget_high_u64(m1));     \
+        b1 = vcombine_u64(vget_high_u64(m2), vget_high_u64(m3));     \
+    } while(0)
+
+#define LOAD_MSG_0_3(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m4), vget_low_u64(m5));       \
+        b1 = vcombine_u64(vget_low_u64(m6), vget_low_u64(m7));       \
+    } while(0)
+
+#define LOAD_MSG_0_4(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m4), vget_high_u64(m5));     \
+        b1 = vcombine_u64(vget_high_u64(m6), vget_high_u64(m7));     \
+    } while(0)
+
+#define LOAD_MSG_1_1(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m7), vget_low_u64(m2));       \
+        b1 = vcombine_u64(vget_high_u64(m4), vget_high_u64(m6));     \
+    } while(0)
+
+#define LOAD_MSG_1_2(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m5), vget_low_u64(m4));       \
+        b1 = vextq_u64(m7, m3, 1);                                   \
+    } while(0)
+
+#define LOAD_MSG_1_3(b0, b1)                                         \
+    do {                                                             \
+        b0 = vextq_u64(m0, m0, 1);                                   \
+        b1 = vcombine_u64(vget_high_u64(m5), vget_high_u64(m2));     \
+    } while(0)
+
+#define LOAD_MSG_1_4(b0, b1)                                         \
+    do {                                                             \
+      b0 = vcombine_u64(vget_low_u64(m6), vget_low_u64(m1));         \
+      b1 = vcombine_u64(vget_high_u64(m3), vget_high_u64(m1));       \
+    } while(0)
+
+#define LOAD_MSG_2_1(b0, b1)                                         \
+    do {                                                             \
+        b0 = vextq_u64(m5, m6, 1);                                   \
+        b1 = vcombine_u64(vget_high_u64(m2), vget_high_u64(m7));     \
+    } while(0)
+
+#define LOAD_MSG_2_2(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m4), vget_low_u64(m0));       \
+        b1 = vcombine_u64(vget_low_u64(m1), vget_high_u64(m6));      \
+    } while(0)
+
+#define LOAD_MSG_2_3(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m5), vget_high_u64(m1));      \
+        b1 = vcombine_u64(vget_high_u64(m3), vget_high_u64(m4));     \
+    } while(0)
+
+#define LOAD_MSG_2_4(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m7), vget_low_u64(m3));       \
+        b1 = vextq_u64(m0, m2, 1);                                   \
+    } while(0)
+
+#define LOAD_MSG_3_1(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m3), vget_high_u64(m1));     \
+        b1 = vcombine_u64(vget_high_u64(m6), vget_high_u64(m5));     \
+    } while(0)
+
+#define LOAD_MSG_3_2(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m4), vget_high_u64(m0));     \
+        b1 = vcombine_u64(vget_low_u64(m6), vget_low_u64(m7));       \
+    } while(0)
+
+#define LOAD_MSG_3_3(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m1), vget_high_u64(m2));      \
+        b1 = vcombine_u64(vget_low_u64(m2), vget_high_u64(m7));      \
+    } while(0)
+
+#define LOAD_MSG_3_4(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m3), vget_low_u64(m5));       \
+        b1 = vcombine_u64(vget_low_u64(m0), vget_low_u64(m4));       \
+    } while(0)
+
+#define LOAD_MSG_4_1(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m4), vget_high_u64(m2));     \
+        b1 = vcombine_u64(vget_low_u64(m1), vget_low_u64(m5));       \
+    } while(0)
+
+#define LOAD_MSG_4_2(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m0), vget_high_u64(m3));      \
+        b1 = vcombine_u64(vget_low_u64(m2), vget_high_u64(m7));      \
+    } while(0)
+
+#define LOAD_MSG_4_3(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m7), vget_high_u64(m5));      \
+        b1 = vcombine_u64(vget_low_u64(m3), vget_high_u64(m1));      \
+    } while(0)
+
+#define LOAD_MSG_4_4(b0, b1)                                         \
+    do {                                                             \
+        b0 = vextq_u64(m0, m6, 1);                                   \
+        b1 = vcombine_u64(vget_low_u64(m4), vget_high_u64(m6));      \
+    } while(0)
+
+#define LOAD_MSG_5_1(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m1), vget_low_u64(m3));       \
+        b1 = vcombine_u64(vget_low_u64(m0), vget_low_u64(m4));       \
+    } while(0)
+
+#define LOAD_MSG_5_2(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m6), vget_low_u64(m5));       \
+        b1 = vcombine_u64(vget_high_u64(m5), vget_high_u64(m1));     \
+    } while(0)
+
+#define LOAD_MSG_5_3(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m2), vget_high_u64(m3));      \
+        b1 = vcombine_u64(vget_high_u64(m7), vget_high_u64(m0));     \
+    } while(0)
+
+#define LOAD_MSG_5_4(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m6), vget_high_u64(m2));     \
+        b1 = vcombine_u64(vget_low_u64(m7), vget_high_u64(m4));      \
+    } while(0)
+
+#define LOAD_MSG_6_1(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m6), vget_high_u64(m0));      \
+        b1 = vcombine_u64(vget_low_u64(m7), vget_low_u64(m2));       \
+    } while(0)
+
+#define LOAD_MSG_6_2(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m2), vget_high_u64(m7));     \
+        b1 = vextq_u64(m6, m5, 1);                                   \
+    } while(0)
+
+#define LOAD_MSG_6_3(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m0), vget_low_u64(m3));       \
+        b1 = vextq_u64(m4, m4, 1);                                   \
+    } while(0)
+
+#define LOAD_MSG_6_4(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m3), vget_high_u64(m1));     \
+        b1 = vcombine_u64(vget_low_u64(m1), vget_high_u64(m5));      \
+    } while(0)
+
+#define LOAD_MSG_7_1(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m6), vget_high_u64(m3));     \
+        b1 = vcombine_u64(vget_low_u64(m6), vget_high_u64(m1));      \
+    } while(0)
+
+#define LOAD_MSG_7_2(b0, b1)                                         \
+    do {                                                             \
+        b0 = vextq_u64(m5, m7, 1);                                   \
+        b1 = vcombine_u64(vget_high_u64(m0), vget_high_u64(m4));     \
+    } while(0)
+
+#define LOAD_MSG_7_3(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m2), vget_high_u64(m7));     \
+        b1 = vcombine_u64(vget_low_u64(m4), vget_low_u64(m1));       \
+    } while(0)
+
+#define LOAD_MSG_7_4(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m0), vget_low_u64(m2));       \
+        b1 = vcombine_u64(vget_low_u64(m3), vget_low_u64(m5));       \
+    } while(0)
+
+#define LOAD_MSG_8_1(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m3), vget_low_u64(m7));       \
+        b1 = vextq_u64(m5, m0, 1);                                   \
+    } while(0)
+
+#define LOAD_MSG_8_2(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m7), vget_high_u64(m4));     \
+        b1 = vextq_u64(m1, m4, 1);                                   \
+    } while(0)
+
+#define LOAD_MSG_8_3(b0, b1)                                         \
+    do {                                                             \
+        b0 = m6;                                                     \
+        b1 = vextq_u64(m0, m5, 1);                                   \
+    } while(0)
+
+#define LOAD_MSG_8_4(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m1), vget_high_u64(m3));      \
+        b1 = m2;                                                     \
+    } while(0)
+
+#define LOAD_MSG_9_1(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m5), vget_low_u64(m4));       \
+        b1 = vcombine_u64(vget_high_u64(m3), vget_high_u64(m0));     \
+    } while(0)
+
+#define LOAD_MSG_9_2(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m1), vget_low_u64(m2));       \
+        b1 = vcombine_u64(vget_low_u64(m3), vget_high_u64(m2));      \
+    } while(0)
+
+#define LOAD_MSG_9_3(b0, b1)                                         \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m7), vget_high_u64(m4));     \
+        b1 = vcombine_u64(vget_high_u64(m1), vget_high_u64(m6));     \
+    } while(0)
+
+#define LOAD_MSG_9_4(b0, b1)                                         \
+    do {                                                             \
+        b0 = vextq_u64(m5, m7, 1);                                   \
+        b1 = vcombine_u64(vget_low_u64(m6), vget_low_u64(m0));       \
+    } while(0)
+
+#define LOAD_MSG_10_1(b0, b1)                                        \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m0), vget_low_u64(m1));       \
+        b1 = vcombine_u64(vget_low_u64(m2), vget_low_u64(m3));       \
+    } while(0)
+
+#define LOAD_MSG_10_2(b0, b1)                                        \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m0), vget_high_u64(m1));     \
+        b1 = vcombine_u64(vget_high_u64(m2), vget_high_u64(m3));     \
+    } while(0)
+
+#define LOAD_MSG_10_3(b0, b1)                                        \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m4), vget_low_u64(m5));       \
+        b1 = vcombine_u64(vget_low_u64(m6), vget_low_u64(m7));       \
+    } while(0)
+
+#define LOAD_MSG_10_4(b0, b1)                                        \
+    do {                                                             \
+        b0 = vcombine_u64(vget_high_u64(m4), vget_high_u64(m5));     \
+        b1 = vcombine_u64(vget_high_u64(m6), vget_high_u64(m7));     \
+    } while(0)
+
+#define LOAD_MSG_11_1(b0, b1)                                        \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m7), vget_low_u64(m2));       \
+        b1 = vcombine_u64(vget_high_u64(m4), vget_high_u64(m6));     \
+    } while(0)
+
+#define LOAD_MSG_11_2(b0, b1)                                        \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m5), vget_low_u64(m4));       \
+        b1 = vextq_u64(m7, m3, 1);                                   \
+    } while(0)
+
+#define LOAD_MSG_11_3(b0, b1)                                        \
+    do {                                                             \
+        b0 = vextq_u64(m0, m0, 1);                                   \
+        b1 = vcombine_u64(vget_high_u64(m5), vget_high_u64(m2));     \
+    } while(0)
+
+#define LOAD_MSG_11_4(b0, b1)                                        \
+    do {                                                             \
+        b0 = vcombine_u64(vget_low_u64(m6), vget_low_u64(m1));       \
+        b1 = vcombine_u64(vget_high_u64(m3), vget_high_u64(m1));     \
+    } while(0)
+
+#endif

--- a/src/libsodium/crypto_generichash/blake2b/ref/blake2b-ref.c
+++ b/src/libsodium/crypto_generichash/blake2b/ref/blake2b-ref.c
@@ -431,6 +431,12 @@ blake2b_pick_best_implementation(void)
         return 0;
     }
 #endif
+#if defined(__aarch64__)
+    if (sodium_runtime_has_neon()) {
+        blake2b_compress = blake2b_compress_neon;
+        return 0;
+    }
+#endif
     blake2b_compress = blake2b_compress_ref;
 
     return 0;


### PR DESCRIPTION
Import NEON acceleration from blake2b-ref. Copyrights reflect those in the upstream files, specifically:
  https://github.com/BLAKE2/BLAKE2/blob/master/neon/blake2b-neon.c

I've restricted this to aarch64 as I do not have an environment in which to test armv7-a support.

Successfully built and run on both aarch64 (Nvidia Grace) and x86_64. Tested on both with `make verify`.