### PR TITLE
Build `libsodium.dll` with VC++ for `win-arm64`

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           name: build-win-x86
           path: bin/Win32/Release/v143/dynamic/libsodium.dll
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-win-arm64
+          path: bin/ARM64/Release/v143/dynamic/libsodium.dll
 
   build-others:
     runs-on: ubuntu-latest
@@ -37,14 +41,6 @@ jobs:
         with:
           version: master
       - uses: actions/checkout@v4
-
-      - name: build-win-arm64
-        run: |
-          rm -fr zig-out zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=aarch64-windows
-      - uses: actions/upload-artifact@v4
-        with:
-          name: build-win-arm64
-          path: zig-out/lib/libsodium.dll
 
       - name: build-linux-x64
         run: |

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: build-win-arm64
-          path: bin/ARM64/Release/v143/dynamic/libsodium.dll
+          path: bin/ARM64/Release/v143/dynamic/libsodium.dll             
 
   build-others:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
 
       - name: build-linux-x64
         run: |
-          rm -fr zig-out zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux-gnu.2.17
+          rm -fr zig-out .zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux-gnu.2.17
       - name: tests
         run: cd zig-out/bin && ./run.sh
       - uses: actions/upload-artifact@v4
@@ -68,7 +68,7 @@ jobs:
 
       - name: build-linux-arm
         run: |
-          rm -fr zig-out zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=arm-linux-gnueabihf.2.23
+          rm -fr zig-out .zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=arm-linux-gnueabihf.2.23
       - name: tests
         run: |
           cd zig-out/bin && env LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib ./run.sh
@@ -79,7 +79,7 @@ jobs:
 
       - name: build-linux-arm64
         run: |
-          rm -fr zig-out zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=aarch64-linux-gnu.2.23
+          rm -fr zig-out .zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=aarch64-linux-gnu.2.23
       - name: tests
         run: |
           cd zig-out/bin && env LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib ./run.sh
@@ -90,7 +90,7 @@ jobs:
 
       - name: build-linux-musl-x64
         run: |
-          rm -fr zig-out zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux-musl
+          rm -fr zig-out .zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux-musl
       - uses: actions/upload-artifact@v4
         with:
           name: build-linux-musl-x64
@@ -98,7 +98,7 @@ jobs:
 
       - name: build-linux-musl-arm
         run: |
-          rm -fr zig-out zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=arm-linux-musleabihf
+          rm -fr zig-out .zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=arm-linux-musleabihf
       - uses: actions/upload-artifact@v4
         with:
           name: build-linux-musl-arm
@@ -106,7 +106,7 @@ jobs:
 
       - name: build-linux-musl-arm64
         run: |
-          rm -fr zig-out zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=aarch64-linux-musl
+          rm -fr zig-out .zig-cache; zig build -Doptimize=ReleaseFast -Dtarget=aarch64-linux-musl
       - uses: actions/upload-artifact@v4
         with:
           name: build-linux-musl-arm64
@@ -143,7 +143,7 @@ jobs:
       - build-apple
       - build-others
     container:
-      image: mcr.microsoft.com/dotnet/sdk:8.0
+      image: mcr.microsoft.com/dotnet/sdk:6.0
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -232,7 +232,7 @@ jobs:
     needs:
       - pack
     container:
-      image: mcr.microsoft.com/dotnet/sdk:8.0
+      image: mcr.microsoft.com/dotnet/sdk:6.0
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -261,9 +261,9 @@ jobs:
       - name: Move Build Output
         run: |
           mkdir .libsodium-builds
-          mv .libsodium-test/bin/Release/net8.0/linux-arm/publish .libsodium-builds/linux-arm
-          mv .libsodium-test/bin/Release/net8.0/linux-arm64/publish .libsodium-builds/linux-arm64
-          mv .libsodium-test/bin/Release/net8.0/linux-x64/publish .libsodium-builds/linux-x64
+          mv .libsodium-test/bin/Release/net6.0/linux-arm/publish .libsodium-builds/linux-arm
+          mv .libsodium-test/bin/Release/net6.0/linux-arm64/publish .libsodium-builds/linux-arm64
+          mv .libsodium-test/bin/Release/net6.0/linux-x64/publish .libsodium-builds/linux-x64
       - uses: actions/upload-artifact@v4
         with:
           name: test-builds
@@ -276,7 +276,7 @@ jobs:
     - build-test-binaries
     strategy:
       matrix:
-        arch: [ 'centos:8', 'debian:11' ]
+        arch: [ 'centos:8', 'debian:10' ]
     container:
       image: ${{ matrix.arch }}
     env:
@@ -292,7 +292,7 @@ jobs:
         .libsodium-builds/linux-x64/Tests
 
   run-test-binaries-cross-plat:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - build-test-binaries
     env:

--- a/builds/msvc/build/buildbase.bat
+++ b/builds/msvc/build/buildbase.bat
@@ -93,9 +93,9 @@ ECHO Configuration=StaticRelease
 msbuild /m /v:n /p:Configuration=StaticRelease /p:Platform=x64 %solution% >> %log%
 IF errorlevel 1 GOTO error
 
-@REM Build ARM64 packages only for Visual studio 19 and later
-IF %version% == 16 (
-  CALL !environment! x86_arm64 > nul
+@REM Build ARM64 packages only for Visual studio 2019 and later
+IF %version% GEQ 16 (
+  CALL !environment! ARM64 > nul
   ECHO Platform=ARM64
 
   ECHO Configuration=DynDebug


### PR DESCRIPTION
Update `buildbase.bat` for `win-arm64`:
- update version check to use *greater-than-or-equal*, i.e. include VS 2019 ***and*** 2022 (or later versions) -- ref. https://ss64.com/nt/if.html section *Test Numeric values*
- select the `ARM64` environment (`x86_arm64` is not valid)

Update `dotnet-core.yml` for `win-arm64`:
- build `libsodium.dll` with VC++ on Windows.
- may help address https://github.com/jedisct1/libsodium/issues/1430