### PR TITLE
Chore/ud artifacts

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -25,7 +25,7 @@ jobs:
         dry-run: false
         language: c++
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -15,11 +15,11 @@ jobs:
         run: buildbase.bat ..\vs2022\libsodium.sln 17
         working-directory: builds/msvc/build/
         shell: cmd
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-win-x64
           path: bin/x64/Release/v143/dynamic/libsodium.dll
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-win-x86
           path: bin/Win32/Release/v143/dynamic/libsodium.dll
@@ -37,7 +37,7 @@ jobs:
           zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux-gnu.2.17 -Dcpu=sandybridge
       - name: tests
         run: cd zig-out/bin && ./run.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-linux-x64
           path: zig-out/lib/libsodium.so
@@ -65,7 +65,7 @@ jobs:
       - name: tests
         run: |
           cd zig-out/bin && env LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib ./run.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-linux-arm
           path: zig-out/lib/libsodium.so
@@ -93,7 +93,7 @@ jobs:
       - name: tests
         run: |
           cd zig-out/bin && env LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib ./run.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-linux-arm64
           path: zig-out/lib/libsodium.so
@@ -118,7 +118,7 @@ jobs:
       - name: tests
         run: |
           cd zig-out/bin && ./run.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-linux-musl-x64
           path: zig-out/lib/libsodium.so
@@ -134,7 +134,7 @@ jobs:
       - name: build
         run: |
           zig build -Doptimize=ReleaseFast -Dtarget=arm-linux-musleabihf -Dcpu=baseline
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-linux-musl-arm
           path: zig-out/lib/libsodium.so
@@ -150,7 +150,7 @@ jobs:
       - name: build
         run: |
           zig build -Doptimize=ReleaseFast -Dtarget=aarch64-linux-musl -Dcpu=baseline
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-linux-musl-arm64
           path: zig-out/lib/libsodium.so
@@ -161,19 +161,19 @@ jobs:
       - uses: actions/checkout@v3
       - name: build-xcframework
         run: env LIBSODIUM_FULL_BUILD=1 LIBSODIUM_SKIP_SIMULATORS=1 dist-build/apple-xcframework.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-macos
           path: libsodium-apple/macos/lib/libsodium.a
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-ios
           path: libsodium-apple/ios/lib/libsodium.a
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-tvos
           path: libsodium-apple/tvos/lib/libsodium.a
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-maccatalyst
           path: libsodium-apple/catalyst/lib/libsodium.a
@@ -200,59 +200,59 @@ jobs:
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-win-x64
           path: .libsodium-pack/runtimes/win-x64/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-win-x86
           path: .libsodium-pack/runtimes/win-x86/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-linux-x64
           path: .libsodium-pack/runtimes/linux-x64/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-linux-arm
           path: .libsodium-pack/runtimes/linux-arm/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-linux-arm64
           path: .libsodium-pack/runtimes/linux-arm64/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-linux-musl-x64
           path: .libsodium-pack/runtimes/linux-musl-x64/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-linux-musl-arm
           path: .libsodium-pack/runtimes/linux-musl-arm/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-linux-musl-arm64
           path: .libsodium-pack/runtimes/linux-musl-arm64/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-macos
           path: .libsodium-pack/runtimes/osx-x64/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-macos
           path: .libsodium-pack/runtimes/osx-arm64/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-ios
           path: .libsodium-pack/runtimes/ios-arm64/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-tvos
           path: .libsodium-pack/runtimes/tvos-arm64/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-maccatalyst
           path: .libsodium-pack/runtimes/maccatalyst-x64/native/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build-maccatalyst
           path: .libsodium-pack/runtimes/maccatalyst-arm64/native/
@@ -260,7 +260,7 @@ jobs:
         run: cp AUTHORS ChangeLog LICENSE packaging/dotnet-core/libsodium.pkgproj .libsodium-pack/
       - name: Create NuGet package
         run: dotnet pack -c Release .libsodium-pack/libsodium.pkgproj
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: nuget-package
           path: .libsodium-pack/bin/Release/*.nupkg
@@ -277,7 +277,7 @@ jobs:
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: nuget-package
           path: .libsodium-pack/
@@ -302,7 +302,7 @@ jobs:
           mv .libsodium-test/bin/Release/net6.0/linux-arm/publish .libsodium-builds/linux-arm
           mv .libsodium-test/bin/Release/net6.0/linux-arm64/publish .libsodium-builds/linux-arm64
           mv .libsodium-test/bin/Release/net6.0/linux-x64/publish .libsodium-builds/linux-x64
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: test-builds
           path: .libsodium-builds/*
@@ -320,7 +320,7 @@ jobs:
     env:
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: test-builds
         path: .libsodium-builds/
@@ -365,7 +365,7 @@ jobs:
           sudo ln -s /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.* /lib
           sudo ln -s /usr/arm-linux-gnueabihf/lib/ld-linux-armhf.so.* /lib
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-builds
           path: .libsodium-builds/

--- a/.github/workflows/relyance-sci.yml
+++ b/.github/workflows/relyance-sci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Pull and run SCI binary
         run: |-

--- a/.github/workflows/relyance-sci.yml
+++ b/.github/workflows/relyance-sci.yml
@@ -1,0 +1,20 @@
+name: Relyance SCI Scan
+
+on:
+  schedule:
+    - cron: "0 20 * * *"
+  workflow_dispatch:
+
+jobs:
+  execute-relyance-sci:
+    name: Relyance SCI Job
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Pull and run SCI binary
+        run: |-
+          docker pull gcr.io/relyance-ext/compliance_inspector:release && \
+          docker run --rm -v `pwd`:/repo --env API_KEY='${{ secrets.DPP_SCI_KEY }}' gcr.io/relyance-ext/compliance_inspector:release


### PR DESCRIPTION
Update `upload-artifact` and `download-artifact` from EoL v3 version to the latest v4 version.

The breaking changes don't seem impactful on the usage: https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes