### PR TITLE
Android build scripts update for SDK level

### DIFF
--- a/dist-build/android-aar.sh
+++ b/dist-build/android-aar.sh
@@ -13,7 +13,7 @@ if [ -z "$NDK_PLATFORM" ]; then
   echo "Compiling for default platform: [${NDK_PLATFORM}] - That can be changed by setting an NDK_PLATFORM environment variable."
 fi
 
-export SDK_VERSION=$( echo "$NDK_PLATFORM" | cut -f2 -d"-" )
+SDK_VERSION=$( echo "$NDK_PLATFORM" | cut -f2 -d"-" )
 
 
 if which zip >/dev/null; then

--- a/dist-build/android-armv8-a.sh
+++ b/dist-build/android-armv8-a.sh
@@ -2,4 +2,4 @@
 export TARGET_ARCH=armv8-a+crypto
 export CFLAGS="-Os -march=${TARGET_ARCH}"
 export LDFLAGS="-Wl,-z,max-page-size=16384"
-NDK_PLATFORM=android-21 ARCH=arm64 HOST_COMPILER=aarch64-linux-android "$(dirname "$0")/android-build.sh"
+ARCH=arm64 HOST_COMPILER=aarch64-linux-android "$(dirname "$0")/android-build.sh"

--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -1,9 +1,10 @@
 #! /bin/sh
 
 if [ -z "$NDK_PLATFORM" ]; then
-  export NDK_PLATFORM="android-21"
-  echo "Compiling for default platform: [${NDK_PLATFORM}] - That can be changed by setting an NDK_PLATFORM environment variable."
+  echo "No NDK_PLATFORM specified, set to value such as \"android-{Min_SDK_VERSION}\" or just use android-aar.sh"
+  exit
 fi
+SDK_VERSION=$( echo "$NDK_PLATFORM" | cut -f2 -d"-" )
 export NDK_PLATFORM_COMPAT="${NDK_PLATFORM_COMPAT:-${NDK_PLATFORM}}"
 export NDK_API_VERSION="$(echo "$NDK_PLATFORM" | sed 's/^android-//')"
 export NDK_API_VERSION_COMPAT="$(echo "$NDK_PLATFORM_COMPAT" | sed 's/^android-//')"
@@ -30,8 +31,8 @@ export TOOLCHAIN_DIR="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/${TOOLCHAIN_OS_
 echo "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/${TOOLCHAIN_OS_DIR}/${HOST_COMPILER}"
 
 export PATH="${PATH}:${TOOLCHAIN_DIR}/bin"
-SDK_VERSION_NUM=$(echo $NDK_PLATFORM | cut -d'-' -f2)
-export CC=${CC:-"${HOST_COMPILER}${SDK_VERSION_NUM}-clang"}
+
+export CC=${CC:-"${HOST_COMPILER}${SDK_VERSION}-clang"}
 
 echo
 echo "Warnings related to headers being present but not usable are due to functions"
@@ -88,5 +89,5 @@ NPROCESSORS=$(getconf NPROCESSORS_ONLN 2>/dev/null || getconf _NPROCESSORS_ONLN 
 PROCESSORS=${NPROCESSORS:-3}
 
 make clean &&
-  make -j${PROCESSORS} install &&
+  make -j"${PROCESSORS}" install &&
   echo "libsodium has been installed into ${PREFIX}"

--- a/dist-build/android-x86_64.sh
+++ b/dist-build/android-x86_64.sh
@@ -2,4 +2,4 @@
 export TARGET_ARCH=westmere
 export CFLAGS="-Os -march=${TARGET_ARCH}"
 export LDFLAGS="-Wl,-z,max-page-size=16384"
-NDK_PLATFORM=android-21 ARCH=x86_64 HOST_COMPILER=x86_64-linux-android "$(dirname "$0")/android-build.sh"
+ARCH=x86_64 HOST_COMPILER=x86_64-linux-android "$(dirname "$0")/android-build.sh"


### PR DESCRIPTION
Changed default SDK level to 21; 
enabled specifying NDK_PLATFORM environment variable for custom SDK level before running android-aar.sh; 
misc cleanup of Android build scripts including removing incorrect comment about static libs which was incorrect and related to an un-merged version of the build scripts.