### PR TITLE
Add Apple XCFramework build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,3 +178,27 @@ jobs:
       - name: Android compilation
         run: |
           env ANDROID_NDK_HOME=/tmp/android/ndk ./dist-build/android-aar.sh
+
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update packages list
+        run: brew update
+
+      - name: Install base dependencies
+        run: brew install libtool autoconf automake
+
+      - name: Autogen
+        run: ./autogen.sh -s
+
+      - name: ios framework compilation
+        run: |
+          ./dist-build/apple-xcframework.sh
+
+      # TODO
+      # - zip xcframework
+      #   - add version to zip name
+      # - upload artifact
+


### PR DESCRIPTION
I'm trying to get an update CocoaPods spec out for libsodium 1.0.20 and future versions.  

I have a [PR into their repo](https://github.com/CocoaPods/Specs/pull/14613), but it's the outdated static format.  I'd like to create a downloadable `libsodium-1.0.20.xcframework.zip` or `.tar.gz` file and have that be the basis of the CocoaPods spec, but I'm not sure how to get a new file out to downloads.  This is my attempt.

ex: [OpenSSL-Universal ](https://github.com/CocoaPods/Specs/blob/master/Specs/e/d/6/OpenSSL-Universal/3.3.3001/OpenSSL-Universal.podspec.json)spec