### PR TITLE
make build.zig emit position independent code by default

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -154,6 +154,7 @@ pub fn build(b: *std.Build) !void {
     const benchmarks_iterations = b.option(u32, "iterations", "Number of iterations for benchmarks.") orelse 200;
     var build_static = b.option(bool, "static", "Build libsodium as a static library.") orelse true;
     var build_shared = b.option(bool, "shared", "Build libsodium as a shared library.") orelse true;
+    const build_pie = b.option(bool, "pie", "Build libsodium as position-independent code.") orelse true;
 
     const build_tests = b.option(bool, "test", "Build the tests (implies -Dstatic=true)") orelse true;
 
@@ -221,6 +222,7 @@ pub fn build(b: *std.Build) !void {
             "-fno-strict-aliasing",
             "-fno-strict-overflow",
             "-fwrapv",
+            if (build_pie) "-fPIC" else "-fno-PIC",
             "-flax-vector-conversions",
         };
 


### PR DESCRIPTION
i noticed that build.zig doesn't pass `-fPIC` as a compile flag, so i made it and option and default.

one thing, due to the iomageddon in zig 0.15.1 i made this change against the git revision before compatibility with zig 0.15.1, for i fear a bunch of projects will have trouble for some time to update their code to zig 0.15.1 (myself definitely) and for those (and most importantly myself) i'd appreciate if there would be a branch that has 0.14.1 compatibility and this patch. if i'm not imposing with this too much.

with this patch i'm able to cross-compile https://github.com/stef/klutshnik as pie-static binary. which pleases me very much!