### PR TITLE
Fixed incorrect checking of points on membership in big prime subgrou…

### DIFF
--- a/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
+++ b/src/libsodium/crypto_core/ed25519/ref10/ed25519_ref10.c
@@ -1040,14 +1040,27 @@ ge25519_is_on_curve(const ge25519_p3 *p)
     return fe25519_iszero(t0);
 }
 
-int
-ge25519_is_on_main_subgroup(const ge25519_p3 *p)
+int ge25519_is_point_at_infinity(const unsigned char *p)
+{
+    // just Edwards point at infinity (0, 1) in compressed form:
+    const unsigned char short_infinity_point[32] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+    return sodium_memcmp(short_infinity_point, p, 32) == 0 ? 1 : 0;
+}
+
+int ge25519_is_on_main_subgroup(const ge25519_p3 *p)
 {
     ge25519_p3 pl;
+    unsigned char short_pl[32];
 
     ge25519_mul_l(&pl, p);
 
-    return fe25519_iszero(pl.X);
+    ge25519_p3_tobytes(short_pl, &pl);
+
+    return ge25519_is_point_at_infinity(short_pl);
 }
 
 int


### PR DESCRIPTION
Function crypto_core_ed25519_is_valid_point must check member ship of point to the big prime order subgroup Q
(except point at infinity). 
All prior versions of library could not catch big set of points outside of Q that constructed like this:                                 point of order 2: T2 = (0, -1) 
base point multiplied by natural n : BaseN = n*Base 
PoisonedPoint = T2 + BaseN 
PoisonedPoint could not be detected by check with crypto_core_ed25519_is_valid_point, because of incorrect 
implementation of function ge25519_is_on_main_subgroup that just multiplies point by number l, order of big subgroup. The logic of check is following : all points from Q have order l (except point at infinity) and thus the result of  scalar multiplication by l must be point at infinity. Incorrect check was that only x coordinate (in extended coordinates form (X, Y, Z, T) ) was compared with zero that gave possibilities to pass test for so cold PoisonedPoint = T2 + BaseN: 
l*PoisonedPoint = l*(T2 + BaseN) = T2 + PointAtInfinity = T2 

As fas as T2 also has x coordinate = 0 ( like point at infinity (0, 1) ) and y coordinate was neglected in the check, all points constructed this way was not detected. The number of such points is big and equal to l - 2             
 
Corrected check will catch such points. For example 
//  (0, -1) + base point, that doesn't belong to the big prime subgroup
// and it must be catched by crypto_core_ed25519_is_valid_point
// (as any other point outside big prime subgroup)
static const unsigned char ed25519_base_plus_order_2[32] = {
    0x95, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
    0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
    0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
    0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99};

if (crypto_core_ed25519_is_valid_point(ed25519_base_plus_order_2) == 1)
{
        printf("crypto_core_ed25519_is_valid_point() failed !!! \n");
}
assert(crypto_core_ed25519_is_valid_point(ed25519_base_plus_order_2) == 0);
