### PR TITLE
build.zig: fix using as a dependency in other projects

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -170,7 +170,8 @@ fn initLibConfig(b: *std.Build, target: std.Build.ResolvedTarget, lib: *Compile)
 
 pub fn build(b: *std.Build) !void {
     const io: Io = if (is_zig_16) b.graph.io else {};
-    const cwd = if (is_zig_16) Dir.cwd() else std.fs.cwd();
+    const root_path = b.pathFromRoot(".");
+    const cwd = try if (is_zig_16) Dir.cwd().openDir(io, root_path, .{}) else std.fs.cwd().openDir(root_path, .{});
 
     const src_path = "src/libsodium";
     const src_dir = if (is_zig_16)


### PR DESCRIPTION
This was originally fixed in 5191b40accb6c860c6d1292c4149c7bea42aca63 but regressed in a8cc2d1f7228252e2d1150cd04dd234b6d52df53.