### PR TITLE
Zero AEGIS cipher state and sensitive locals after use

### DIFF
--- a/src/libsodium/crypto_aead/aegis128l/aegis128l_common.h
+++ b/src/libsodium/crypto_aead/aegis128l/aegis128l_common.h
@@ -164,6 +164,7 @@ encrypt_detached(uint8_t *c, uint8_t *mac, size_t maclen, const uint8_t *m, size
     CRYPTO_ALIGN(RATE) uint8_t src[RATE];
     CRYPTO_ALIGN(RATE) uint8_t dst[RATE];
     size_t                     i;
+    int                        ret;
 
     aegis128l_init(k, npub, state);
 
@@ -188,7 +189,13 @@ encrypt_detached(uint8_t *c, uint8_t *mac, size_t maclen, const uint8_t *m, size
         memcpy(c + i, dst, mlen % RATE);
     }
 
-    return aegis128l_mac(mac, maclen, adlen, mlen, state);
+    ret = aegis128l_mac(mac, maclen, adlen, mlen, state);
+
+    sodium_memzero(state, sizeof state);
+    sodium_memzero(src, sizeof src);
+    sodium_memzero(dst, sizeof dst);
+
+    return ret;
 }
 
 static int
@@ -242,9 +249,13 @@ decrypt_detached(uint8_t *m, const uint8_t *c, size_t clen, const uint8_t *mac, 
             ret = crypto_verify_32(computed_mac, mac);
         }
     }
+    sodium_memzero(state, sizeof state);
+    sodium_memzero(src, sizeof src);
+    sodium_memzero(dst, sizeof dst);
+    sodium_memzero(computed_mac, sizeof computed_mac);
     if (ret != 0) {
         if (m != NULL) {
-            memset(m, 0, mlen);
+            sodium_memzero(m, mlen);
         }
         return ret;
     }

--- a/src/libsodium/crypto_aead/aegis256/aegis256_common.h
+++ b/src/libsodium/crypto_aead/aegis256/aegis256_common.h
@@ -147,6 +147,7 @@ encrypt_detached(uint8_t *c, uint8_t *mac, size_t maclen, const uint8_t *m, size
     CRYPTO_ALIGN(RATE) uint8_t src[RATE];
     CRYPTO_ALIGN(RATE) uint8_t dst[RATE];
     size_t                     i;
+    int                        ret;
 
     aegis256_init(k, npub, state);
 
@@ -171,7 +172,13 @@ encrypt_detached(uint8_t *c, uint8_t *mac, size_t maclen, const uint8_t *m, size
         memcpy(c + i, dst, mlen % RATE);
     }
 
-    return aegis256_mac(mac, maclen, adlen, mlen, state);
+    ret = aegis256_mac(mac, maclen, adlen, mlen, state);
+
+    sodium_memzero(state, sizeof state);
+    sodium_memzero(src, sizeof src);
+    sodium_memzero(dst, sizeof dst);
+
+    return ret;
 }
 
 static int
@@ -225,9 +232,13 @@ decrypt_detached(uint8_t *m, const uint8_t *c, size_t clen, const uint8_t *mac, 
             ret = crypto_verify_32(computed_mac, mac);
         }
     }
+    sodium_memzero(state, sizeof state);
+    sodium_memzero(src, sizeof src);
+    sodium_memzero(dst, sizeof dst);
+    sodium_memzero(computed_mac, sizeof computed_mac);
     if (ret != 0) {
         if (m != NULL) {
-            memset(m, 0, mlen);
+            sodium_memzero(m, mlen);
         }
         return ret;
     }


### PR DESCRIPTION
## Summary

- Add `sodium_memzero()` calls to wipe key-derived cipher state, computed MAC, and scratch buffers (`src`, `dst`) after use in AEGIS-128L and AEGIS-256 `encrypt_detached` and `decrypt_detached` functions.
- Replace plain `memset(m, 0, mlen)` with `sodium_memzero(m, mlen)` when clearing plaintext on authentication failure, preventing the compiler from optimizing the wipe away under `-O3`.
- Aligns AEGIS with the existing practice in `aes256gcm` and `chacha20poly1305`, which already zero sensitive state after use.

## Files changed

- `src/libsodium/crypto_aead/aegis128l/aegis128l_common.h`
- `src/libsodium/crypto_aead/aegis256/aegis256_common.h`

## Test plan

- [x] `make check TESTS="aead_aegis128l aead_aegis256"` passes with no regressions
- [x] Verified all 46 AEGIS-128L and 52 AEGIS-256 KAT vectors still pass
- [x] Confirmed `sodium_memzero` is available via `utils.h` (already included by all backends: aesni, armcrypto, soft)